### PR TITLE
Add EFTA probe-based discovery to supplement HTML scraping

### DIFF
--- a/scripts/pipeline/run-pipeline.ts
+++ b/scripts/pipeline/run-pipeline.ts
@@ -1,4 +1,4 @@
-import { scrapeDOJCatalog } from "./doj-scraper";
+import { scrapeDOJCatalog, probeAndMergeCatalog } from "./doj-scraper";
 import { scrapeWikipediaPersons } from "./wikipedia-scraper";
 import { downloadDocuments } from "./document-downloader";
 import { processDocuments } from "./pdf-processor";
@@ -24,6 +24,7 @@ interface PipelineConfig {
 
 const STAGES = [
   "scrape-doj",
+  "probe-doj",
   "scrape-wikipedia",
   "download",
   "process",
@@ -57,6 +58,7 @@ USAGE:
 STAGES:
   all              Run all stages in order
   scrape-doj       Scrape DOJ Epstein Library for document catalog
+  probe-doj        Probe sequential EFTA numbers via HEAD requests to discover unlisted files
   scrape-wikipedia Scrape Wikipedia for comprehensive person list
   download         Download documents from DOJ (PDFs, images, etc.)
   process          Extract text from downloaded PDFs via OCR/parsing
@@ -113,6 +115,10 @@ async function runStage(stage: string, config: PipelineConfig): Promise<void> {
     switch (stage) {
       case "scrape-doj":
         await scrapeDOJCatalog();
+        break;
+
+      case "probe-doj":
+        await probeAndMergeCatalog(config.dataSetIds);
         break;
 
       case "scrape-wikipedia":


### PR DESCRIPTION
## Summary
- Port probe logic from bash script into TypeScript for discovering sequential EFTA-numbered files
- Sends batched HEAD requests across 5 file extensions with 15 concurrent connections
- Stops after 500 consecutive misses, efficiently discovering unlisted documents on DOJ pages
- Merges discovered files into existing catalog and integrates as `probe-doj` pipeline stage

## Test plan
- Run `npx tsx scripts/pipeline/doj-scraper.ts probe` to probe all data sets
- Run `npx tsx scripts/pipeline/run-pipeline.ts probe-doj --data-sets 1,2,3` to test pipeline integration
- Verify doj-catalog.json is updated with discovered files

🤖 Generated with [Claude Code](https://claude.com/claude-code)