### PR TITLE
Add pagination, bookmarks, and data export APIs

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -16,8 +16,18 @@ export async function registerRoutes(
     }
   });
 
-  app.get("/api/persons", async (_req, res) => {
+  app.get("/api/persons", async (req, res) => {
     try {
+      const pageParam = req.query.page as string | undefined;
+      const limitParam = req.query.limit as string | undefined;
+
+      if (pageParam) {
+        const page = Math.max(1, parseInt(pageParam) || 1);
+        const limit = Math.min(100, Math.max(1, parseInt(limitParam || "50") || 50));
+        const result = await storage.getPersonsPaginated(page, limit);
+        return res.json(result);
+      }
+
       const persons = await storage.getPersons();
       res.json(persons);
     } catch (error) {
@@ -41,8 +51,18 @@ export async function registerRoutes(
     }
   });
 
-  app.get("/api/documents", async (_req, res) => {
+  app.get("/api/documents", async (req, res) => {
     try {
+      const pageParam = req.query.page as string | undefined;
+      const limitParam = req.query.limit as string | undefined;
+
+      if (pageParam) {
+        const page = Math.max(1, parseInt(pageParam) || 1);
+        const limit = Math.min(100, Math.max(1, parseInt(limitParam || "50") || 50));
+        const result = await storage.getDocumentsPaginated(page, limit);
+        return res.json(result);
+      }
+
       const documents = await storage.getDocuments();
       res.json(documents);
     } catch (error) {
@@ -122,6 +142,145 @@ export async function registerRoutes(
       res.json(summary);
     } catch (error) {
       res.status(500).json({ error: "Failed to fetch budget summary" });
+    }
+  });
+
+  // Bookmark routes
+  app.get("/api/bookmarks", async (_req, res) => {
+    try {
+      const bookmarks = await storage.getBookmarks();
+      res.json(bookmarks);
+    } catch (error) {
+      res.status(500).json({ error: "Failed to fetch bookmarks" });
+    }
+  });
+
+  app.post("/api/bookmarks", async (req, res) => {
+    try {
+      const { entityType, entityId, searchQuery, label, userId } = req.body;
+      if (!entityType || !["person", "document", "search"].includes(entityType)) {
+        return res.status(400).json({ error: "entityType must be 'person', 'document', or 'search'" });
+      }
+      const bookmark = await storage.createBookmark({
+        entityType,
+        entityId: entityId ?? null,
+        searchQuery: searchQuery ?? null,
+        label: label ?? null,
+        userId: userId ?? "anonymous",
+      });
+      res.status(201).json(bookmark);
+    } catch (error) {
+      res.status(500).json({ error: "Failed to create bookmark" });
+    }
+  });
+
+  app.delete("/api/bookmarks/:id", async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      if (isNaN(id)) {
+        return res.status(400).json({ error: "Invalid ID" });
+      }
+      const deleted = await storage.deleteBookmark(id);
+      if (!deleted) {
+        return res.status(404).json({ error: "Bookmark not found" });
+      }
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ error: "Failed to delete bookmark" });
+    }
+  });
+
+  // Data export routes
+  app.get("/api/export/persons", async (req, res) => {
+    try {
+      const format = (req.query.format as string) || "json";
+      const persons = await storage.getPersons();
+
+      if (format === "csv") {
+        const headers = ["id", "name", "role", "description", "status", "nationality", "occupation", "category", "documentCount", "connectionCount"];
+        const csvRows = [headers.join(",")];
+        for (const p of persons) {
+          csvRows.push(headers.map(h => {
+            const val = String((p as any)[h] ?? "");
+            return val.includes(",") || val.includes('"') || val.includes("\n")
+              ? `"${val.replace(/"/g, '""')}"` : val;
+          }).join(","));
+        }
+        res.setHeader("Content-Type", "text/csv");
+        res.setHeader("Content-Disposition", "attachment; filename=persons.csv");
+        return res.send(csvRows.join("\n"));
+      }
+
+      res.setHeader("Content-Type", "application/json");
+      res.setHeader("Content-Disposition", "attachment; filename=persons.json");
+      res.json(persons);
+    } catch (error) {
+      res.status(500).json({ error: "Failed to export persons" });
+    }
+  });
+
+  app.get("/api/export/documents", async (req, res) => {
+    try {
+      const format = (req.query.format as string) || "json";
+      const documents = await storage.getDocuments();
+
+      if (format === "csv") {
+        const headers = ["id", "title", "documentType", "dataSet", "datePublished", "dateOriginal", "pageCount", "isRedacted", "processingStatus", "aiAnalysisStatus"];
+        const csvRows = [headers.join(",")];
+        for (const d of documents) {
+          csvRows.push(headers.map(h => {
+            const val = String((d as any)[h] ?? "");
+            return val.includes(",") || val.includes('"') || val.includes("\n")
+              ? `"${val.replace(/"/g, '""')}"` : val;
+          }).join(","));
+        }
+        res.setHeader("Content-Type", "text/csv");
+        res.setHeader("Content-Disposition", "attachment; filename=documents.csv");
+        return res.send(csvRows.join("\n"));
+      }
+
+      res.setHeader("Content-Type", "application/json");
+      res.setHeader("Content-Disposition", "attachment; filename=documents.json");
+      res.json(documents);
+    } catch (error) {
+      res.status(500).json({ error: "Failed to export documents" });
+    }
+  });
+
+  app.get("/api/export/search", async (req, res) => {
+    try {
+      const query = (req.query.q as string) || "";
+      const format = (req.query.format as string) || "json";
+
+      if (query.length < 2) {
+        return res.status(400).json({ error: "Query must be at least 2 characters" });
+      }
+
+      const results = await storage.search(query);
+
+      res.setHeader("Content-Type", format === "csv" ? "text/csv" : "application/json");
+      res.setHeader("Content-Disposition", `attachment; filename=search-results.${format === "csv" ? "csv" : "json"}`);
+
+      if (format === "csv") {
+        const rows = ["type,id,name_or_title,description"];
+        for (const p of results.persons) {
+          const desc = (p.description || "").replace(/"/g, '""');
+          rows.push(`person,${p.id},"${p.name.replace(/"/g, '""')}","${desc}"`);
+        }
+        for (const d of results.documents) {
+          const desc = (d.description || "").replace(/"/g, '""');
+          rows.push(`document,${d.id},"${d.title.replace(/"/g, '""')}","${desc}"`);
+        }
+        for (const e of results.events) {
+          const desc = (e.description || "").replace(/"/g, '""');
+          rows.push(`event,${e.id},"${e.title.replace(/"/g, '""')}","${desc}"`);
+        }
+        return res.send(rows.join("\n"));
+      }
+
+      res.json(results);
+    } catch (error) {
+      res.status(500).json({ error: "Failed to export search results" });
     }
   });
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -165,3 +165,17 @@ export const insertUserSchema = createInsertSchema(users).pick({
   username: true,
   password: true,
 });
+
+export const bookmarks = pgTable("bookmarks", {
+  id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+  userId: text("user_id").notNull().default("anonymous"),
+  entityType: text("entity_type").notNull(), // 'person' | 'document' | 'search'
+  entityId: integer("entity_id"),
+  searchQuery: text("search_query"),
+  label: text("label"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export const insertBookmarkSchema = createInsertSchema(bookmarks).omit({ id: true, createdAt: true });
+export type Bookmark = typeof bookmarks.$inferSelect;
+export type InsertBookmark = z.infer<typeof insertBookmarkSchema>;


### PR DESCRIPTION
## Summary

Implements backend infrastructure for pagination, bookmarks, and data export:
- Added pagination support to `/api/persons` and `/api/documents` endpoints (backward-compatible)
- Implemented bookmarks table and CRUD API routes
- Added data export endpoints for CSV and JSON formats

## Changes

- **Schema**: Added `bookmarks` table with userId, entityType, entityId, searchQuery, label, createdAt
- **Storage**: Added paginated query methods and bookmark management
- **Routes**: Added pagination params, /api/bookmarks endpoints, and /api/export/* routes

All changes are backward compatible—existing consumers work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)