### PR TITLE
Build visual timeline with year grouping and advanced filters

### DIFF
--- a/client/src/components/timeline-viz.tsx
+++ b/client/src/components/timeline-viz.tsx
@@ -1,0 +1,242 @@
+import { useState, useMemo } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
+import {
+  Clock,
+  Scale,
+  AlertTriangle,
+  FileText,
+  Users,
+  Plane,
+  Gavel,
+  Building2,
+  ChevronRight,
+} from "lucide-react";
+import type { TimelineEvent } from "@shared/schema";
+
+const categoryIcons: Record<string, React.ComponentType<{ className?: string }>> = {
+  legal: Scale,
+  arrest: AlertTriangle,
+  investigation: FileText,
+  travel: Plane,
+  court: Gavel,
+  political: Building2,
+  death: AlertTriangle,
+  disclosure: FileText,
+  relationship: Users,
+};
+
+const categoryBadgeColors: Record<string, string> = {
+  legal: "bg-chart-2/10 text-chart-2",
+  arrest: "bg-destructive/10 text-destructive",
+  investigation: "bg-primary/10 text-primary",
+  travel: "bg-chart-3/10 text-chart-3",
+  court: "bg-chart-4/10 text-chart-4",
+  political: "bg-chart-5/10 text-chart-5",
+  death: "bg-destructive/10 text-destructive",
+  disclosure: "bg-primary/10 text-primary",
+  relationship: "bg-chart-2/10 text-chart-2",
+};
+
+const categoryNodeColors: Record<string, string> = {
+  legal: "bg-chart-2",
+  arrest: "bg-destructive",
+  investigation: "bg-primary",
+  travel: "bg-chart-3",
+  court: "bg-chart-4",
+  political: "bg-chart-5",
+  death: "bg-destructive",
+  disclosure: "bg-primary",
+  relationship: "bg-chart-2",
+};
+
+const significanceSize: Record<number, { dot: string; ring: string }> = {
+  1: { dot: "w-3 h-3", ring: "w-5 h-5" },
+  2: { dot: "w-4 h-4", ring: "w-6 h-6" },
+  3: { dot: "w-5 h-5", ring: "w-7 h-7" },
+};
+
+interface YearGroup {
+  year: number;
+  events: TimelineEvent[];
+}
+
+function groupByYear(events: TimelineEvent[]): YearGroup[] {
+  const map = new Map<number, TimelineEvent[]>();
+  for (const event of events) {
+    const year = parseInt(event.date.slice(0, 4), 10);
+    if (!map.has(year)) map.set(year, []);
+    map.get(year)!.push(event);
+  }
+  return Array.from(map.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([year, events]) => ({ year, events }));
+}
+
+function formatDate(date: string): string {
+  const [y, m, d] = date.split("-");
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  return `${months[parseInt(m, 10) - 1]} ${parseInt(d, 10)}, ${y}`;
+}
+
+interface TimelineVizProps {
+  events: TimelineEvent[];
+}
+
+export default function TimelineViz({ events }: TimelineVizProps) {
+  const [collapsedYears, setCollapsedYears] = useState<Set<number>>(new Set());
+
+  const yearGroups = useMemo(() => groupByYear(events), [events]);
+
+  const toggleYear = (year: number) => {
+    setCollapsedYears((prev) => {
+      const next = new Set(prev);
+      if (next.has(year)) next.delete(year);
+      else next.add(year);
+      return next;
+    });
+  };
+
+  if (events.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 gap-3">
+        <Clock className="w-10 h-10 text-muted-foreground/40" />
+        <p className="text-sm text-muted-foreground">No events match your filters.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      {/* Vertical timeline spine */}
+      <div className="absolute left-4 md:left-1/2 top-0 bottom-0 w-px bg-border md:-translate-x-px" />
+
+      {yearGroups.map((group) => {
+        const isOpen = !collapsedYears.has(group.year);
+        const keyCount = group.events.filter((e) => e.significance >= 2).length;
+
+        return (
+          <Collapsible
+            key={group.year}
+            open={isOpen}
+            onOpenChange={() => toggleYear(group.year)}
+          >
+            {/* Year header */}
+            <CollapsibleTrigger asChild>
+              <button
+                className="relative z-10 flex items-center gap-2 mb-2 mt-6 first:mt-0 group cursor-pointer w-full md:justify-center"
+                style={{ paddingLeft: "0" }}
+              >
+                <div className="flex items-center gap-2 bg-background px-3 py-1.5 rounded-full border border-border shadow-sm">
+                  <ChevronRight
+                    className={`w-3.5 h-3.5 text-muted-foreground transition-transform ${
+                      isOpen ? "rotate-90" : ""
+                    }`}
+                  />
+                  <span className="text-lg font-bold tracking-tight">{group.year}</span>
+                  <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                    {group.events.length}
+                  </Badge>
+                  {keyCount > 0 && (
+                    <Badge variant="secondary" className="text-[10px] px-1.5 py-0 bg-primary/10 text-primary">
+                      {keyCount} key
+                    </Badge>
+                  )}
+                </div>
+              </button>
+            </CollapsibleTrigger>
+
+            <CollapsibleContent>
+              <div className="flex flex-col gap-1">
+                {group.events.map((event, idx) => {
+                  const Icon = categoryIcons[event.category] || Clock;
+                  const nodeColor = categoryNodeColors[event.category] || "bg-muted-foreground";
+                  const size = significanceSize[event.significance] || significanceSize[1];
+                  const isHigh = event.significance >= 3;
+                  const isLeft = idx % 2 === 0;
+
+                  return (
+                    <div
+                      key={event.id}
+                      className="relative py-2"
+                      data-testid={`card-event-${event.id}`}
+                    >
+                      {/* Mobile: single column with left spine */}
+                      <div className="md:hidden flex items-start gap-3 pl-0">
+                        {/* Node on the spine */}
+                        <div className="relative z-10 flex items-center justify-center shrink-0 w-8">
+                          <div className={`${size.ring} rounded-full flex items-center justify-center ${isHigh ? "bg-primary/15" : ""}`}>
+                            <div className={`${size.dot} rounded-full ${nodeColor} ring-2 ring-background`} />
+                          </div>
+                        </div>
+                        <EventCard event={event} Icon={Icon} nodeColor={nodeColor} isHigh={isHigh} />
+                      </div>
+
+                      {/* Desktop: alternating left/right */}
+                      <div className="hidden md:grid md:grid-cols-[1fr_auto_1fr] md:gap-4 items-start">
+                        {/* Left column */}
+                        <div className={`flex ${isLeft ? "justify-end" : ""}`}>
+                          {isLeft && <EventCard event={event} Icon={Icon} nodeColor={nodeColor} isHigh={isHigh} align="right" />}
+                        </div>
+
+                        {/* Center node */}
+                        <div className="relative z-10 flex items-center justify-center w-8">
+                          <div className={`${size.ring} rounded-full flex items-center justify-center ${isHigh ? "bg-primary/15" : ""}`}>
+                            <div className={`${size.dot} rounded-full ${nodeColor} ring-2 ring-background`} />
+                          </div>
+                        </div>
+
+                        {/* Right column */}
+                        <div className={`flex ${!isLeft ? "justify-start" : ""}`}>
+                          {!isLeft && <EventCard event={event} Icon={Icon} nodeColor={nodeColor} isHigh={isHigh} align="left" />}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        );
+      })}
+    </div>
+  );
+}
+
+function EventCard({
+  event,
+  Icon,
+  nodeColor,
+  isHigh,
+  align = "left",
+}: {
+  event: TimelineEvent;
+  Icon: React.ComponentType<{ className?: string }>;
+  nodeColor: string;
+  isHigh: boolean;
+  align?: "left" | "right";
+}) {
+  return (
+    <Card className={`flex-1 max-w-md ${isHigh ? "border-primary/30" : ""} ${align === "right" ? "text-right" : ""}`}>
+      <CardContent className="p-3">
+        <div className={`flex flex-col gap-1.5 ${align === "right" ? "items-end" : "items-start"}`}>
+          <div className={`flex items-center gap-1.5 flex-wrap ${align === "right" ? "flex-row-reverse" : ""}`}>
+            <span className="text-[11px] font-mono text-muted-foreground">{formatDate(event.date)}</span>
+            <Badge
+              variant="secondary"
+              className={`text-[10px] px-1 py-0 ${categoryBadgeColors[event.category] || ""}`}
+            >
+              <Icon className="w-2.5 h-2.5 mr-0.5" />
+              {event.category}
+            </Badge>
+          </div>
+          <h3 className={`text-sm font-semibold leading-tight ${isHigh ? "text-foreground" : "text-foreground/80"}`}>
+            {event.title}
+          </h3>
+          <p className="text-xs text-muted-foreground leading-relaxed">{event.description}</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/pages/timeline.tsx
+++ b/client/src/pages/timeline.tsx
@@ -1,69 +1,73 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "wouter";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import {
   Clock,
-  Scale,
-  AlertTriangle,
-  FileText,
-  Users,
-  Plane,
-  Gavel,
-  Building2,
   Filter,
+  Eye,
+  Star,
+  X,
 } from "lucide-react";
 import type { TimelineEvent } from "@shared/schema";
+import TimelineViz from "@/components/timeline-viz";
 
-const categoryIcons: Record<string, any> = {
-  legal: Scale,
-  arrest: AlertTriangle,
-  investigation: FileText,
-  travel: Plane,
-  court: Gavel,
-  political: Building2,
-  death: AlertTriangle,
-  disclosure: FileText,
-  relationship: Users,
-};
-
-const categoryBadgeColors: Record<string, string> = {
-  legal: "bg-chart-2/10 text-chart-2",
-  arrest: "bg-destructive/10 text-destructive",
-  investigation: "bg-primary/10 text-primary",
-  travel: "bg-chart-3/10 text-chart-3",
-  court: "bg-chart-4/10 text-chart-4",
-  political: "bg-chart-5/10 text-chart-5",
-  death: "bg-destructive/10 text-destructive",
-  disclosure: "bg-primary/10 text-primary",
-  relationship: "bg-chart-2/10 text-chart-2",
-};
-
-const significanceDots: Record<number, string> = {
-  1: "w-2 h-2",
-  2: "w-2.5 h-2.5",
-  3: "w-3 h-3",
-};
+const DECADES = [
+  { label: "1950s", start: 1950, end: 1959 },
+  { label: "1980s", start: 1980, end: 1989 },
+  { label: "1990s", start: 1990, end: 1999 },
+  { label: "2000s", start: 2000, end: 2009 },
+  { label: "2010s", start: 2010, end: 2019 },
+  { label: "2020s", start: 2020, end: 2029 },
+];
 
 export default function TimelinePage() {
   const [categoryFilter, setCategoryFilter] = useState("all");
+  const [zoomLevel, setZoomLevel] = useState<"all" | "key">("all");
+  const [yearFrom, setYearFrom] = useState("");
+  const [yearTo, setYearTo] = useState("");
 
   const { data: events, isLoading } = useQuery<TimelineEvent[]>({
     queryKey: ["/api/timeline"],
   });
 
-  const categories = ["all", ...new Set(events?.map((e) => e.category) || [])];
-
-  const filtered = events?.filter(
-    (e) => categoryFilter === "all" || e.category === categoryFilter
+  const categories = useMemo(
+    () => ["all", ...new Set(events?.map((e) => e.category) || [])],
+    [events]
   );
 
+  const filtered = useMemo(() => {
+    if (!events) return [];
+    return events.filter((e) => {
+      if (categoryFilter !== "all" && e.category !== categoryFilter) return false;
+      if (zoomLevel === "key" && e.significance < 2) return false;
+      const year = parseInt(e.date.slice(0, 4), 10);
+      if (yearFrom && year < parseInt(yearFrom, 10)) return false;
+      if (yearTo && year > parseInt(yearTo, 10)) return false;
+      return true;
+    });
+  }, [events, categoryFilter, zoomLevel, yearFrom, yearTo]);
+
+  const hasActiveFilters = categoryFilter !== "all" || zoomLevel !== "all" || yearFrom || yearTo;
+
+  const clearFilters = () => {
+    setCategoryFilter("all");
+    setZoomLevel("all");
+    setYearFrom("");
+    setYearTo("");
+  };
+
+  const jumpToDecade = (start: number, end: number) => {
+    setYearFrom(String(start));
+    setYearTo(String(end));
+  };
+
   return (
-    <div className="flex flex-col gap-6 p-6 max-w-4xl mx-auto w-full">
+    <div className="flex flex-col gap-6 p-6 max-w-5xl mx-auto w-full">
+      {/* Header */}
       <div className="flex flex-col gap-2">
         <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2" data-testid="text-timeline-title">
           <Clock className="w-6 h-6 text-primary" />
@@ -74,10 +78,36 @@ export default function TimelinePage() {
         </p>
       </div>
 
+      {/* Decade quick-jump */}
+      <div className="flex items-center gap-1.5 flex-wrap">
+        <span className="text-xs text-muted-foreground mr-1">Jump to:</span>
+        {DECADES.map((d) => (
+          <Button
+            key={d.label}
+            variant={yearFrom === String(d.start) && yearTo === String(d.end) ? "default" : "outline"}
+            size="sm"
+            className="h-7 text-xs px-2.5"
+            onClick={() => {
+              if (yearFrom === String(d.start) && yearTo === String(d.end)) {
+                setYearFrom("");
+                setYearTo("");
+              } else {
+                jumpToDecade(d.start, d.end);
+              }
+            }}
+          >
+            {d.label}
+          </Button>
+        ))}
+      </div>
+
+      {/* Filters row */}
       <div className="flex items-center gap-2 flex-wrap">
         <Filter className="w-3 h-3 text-muted-foreground" />
+
+        {/* Category filter */}
         <Select value={categoryFilter} onValueChange={setCategoryFilter}>
-          <SelectTrigger className="w-44" data-testid="select-timeline-category">
+          <SelectTrigger className="w-40 h-8 text-xs" data-testid="select-timeline-category">
             <SelectValue placeholder="Category" />
           </SelectTrigger>
           <SelectContent>
@@ -88,77 +118,97 @@ export default function TimelinePage() {
             ))}
           </SelectContent>
         </Select>
-        {categoryFilter !== "all" && (
-          <Button variant="ghost" size="sm" onClick={() => setCategoryFilter("all")} data-testid="button-clear-timeline-filter">
-            Clear
+
+        {/* Zoom level toggle */}
+        <div className="flex items-center border border-border rounded-md overflow-hidden">
+          <Button
+            variant={zoomLevel === "all" ? "default" : "ghost"}
+            size="sm"
+            className="h-8 text-xs rounded-none px-2.5"
+            onClick={() => setZoomLevel("all")}
+          >
+            <Eye className="w-3 h-3 mr-1" />
+            All
+          </Button>
+          <Button
+            variant={zoomLevel === "key" ? "default" : "ghost"}
+            size="sm"
+            className="h-8 text-xs rounded-none px-2.5"
+            onClick={() => setZoomLevel("key")}
+          >
+            <Star className="w-3 h-3 mr-1" />
+            Key Only
+          </Button>
+        </div>
+
+        {/* Year range */}
+        <div className="flex items-center gap-1">
+          <Input
+            type="number"
+            placeholder="From"
+            value={yearFrom}
+            onChange={(e) => setYearFrom(e.target.value)}
+            className="w-20 h-8 text-xs"
+            min={1950}
+            max={2030}
+          />
+          <span className="text-xs text-muted-foreground">—</span>
+          <Input
+            type="number"
+            placeholder="To"
+            value={yearTo}
+            onChange={(e) => setYearTo(e.target.value)}
+            className="w-20 h-8 text-xs"
+            min={1950}
+            max={2030}
+          />
+        </div>
+
+        {hasActiveFilters && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 text-xs"
+            onClick={clearFilters}
+            data-testid="button-clear-timeline-filter"
+          >
+            <X className="w-3 h-3 mr-1" />
+            Clear all
           </Button>
         )}
       </div>
 
+      {/* Event count */}
+      {!isLoading && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Badge variant="secondary" className="text-[10px]">
+            {filtered.length} event{filtered.length !== 1 ? "s" : ""}
+          </Badge>
+          {hasActiveFilters && events && (
+            <span>of {events.length} total</span>
+          )}
+        </div>
+      )}
+
+      {/* Timeline content */}
       {isLoading ? (
-        <div className="flex flex-col gap-4">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <div key={i} className="flex gap-4">
-              <Skeleton className="w-24 h-6" />
-              <Skeleton className="h-20 flex-1" />
+        <div className="flex flex-col gap-6">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex flex-col gap-3">
+              <Skeleton className="w-32 h-8 mx-auto rounded-full" />
+              <div className="flex gap-4 items-start">
+                <Skeleton className="w-8 h-8 rounded-full shrink-0" />
+                <Skeleton className="h-24 flex-1 rounded-lg" />
+              </div>
+              <div className="flex gap-4 items-start">
+                <Skeleton className="h-20 flex-1 rounded-lg" />
+                <Skeleton className="w-8 h-8 rounded-full shrink-0" />
+              </div>
             </div>
           ))}
         </div>
       ) : (
-        <div className="relative">
-          <div className="absolute left-[7px] top-2 bottom-2 w-px bg-border" />
-          <div className="flex flex-col gap-1">
-            {filtered?.map((event, index) => {
-              const Icon = categoryIcons[event.category] || Clock;
-              const dotSize = significanceDots[event.significance] || significanceDots[1];
-              const isHighSignificance = event.significance >= 3;
-
-              return (
-                <div key={event.id} className="relative flex items-start gap-4 py-3 group">
-                  <div className="relative z-10 flex items-center justify-center shrink-0">
-                    <div
-                      className={`${dotSize} rounded-full ${
-                        isHighSignificance ? "bg-primary" : "bg-muted-foreground/40"
-                      } ring-2 ring-background`}
-                    />
-                  </div>
-
-                  <Card className={`flex-1 ${isHighSignificance ? "border-primary/20" : ""}`} data-testid={`card-event-${event.id}`}>
-                    <CardContent className="p-4">
-                      <div className="flex flex-col gap-2">
-                        <div className="flex items-start justify-between gap-2 flex-wrap">
-                          <div className="flex items-center gap-2">
-                            <span className="text-xs font-mono text-muted-foreground">{event.date}</span>
-                            <Badge
-                              variant="secondary"
-                              className={`text-[10px] ${categoryBadgeColors[event.category] || ""}`}
-                            >
-                              <Icon className="w-2.5 h-2.5 mr-0.5" />
-                              {event.category}
-                            </Badge>
-                          </div>
-                        </div>
-                        <h3 className={`text-sm font-semibold ${isHighSignificance ? "text-foreground" : ""}`}>
-                          {event.title}
-                        </h3>
-                        <p className="text-xs text-muted-foreground leading-relaxed">{event.description}</p>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </div>
-              );
-            })}
-          </div>
-          {filtered?.length === 0 && (
-            <div className="flex flex-col items-center justify-center py-16 gap-3 relative z-10">
-              <Clock className="w-10 h-10 text-muted-foreground/40" />
-              <p className="text-sm text-muted-foreground">No events match this filter.</p>
-              <Button variant="outline" size="sm" onClick={() => setCategoryFilter("all")}>
-                Show all events
-              </Button>
-            </div>
-          )}
-        </div>
+        <TimelineViz events={filtered} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Replaces the flat timeline with a year-grouped, collapsible visualization featuring:
- Year-based grouping with collapsible sections showing event count and key event badges
- Alternating left/right desktop layout with vertical timeline spine
- Decade quick-jump navigation for instant access to major periods
- Zoom levels: "All events" vs "Key events only" (significance ≥ 2)
- Year range filtering (from–to inputs)
- Event significance reflected in node sizing (1–3 scale)
- High-impact events (significance 3) visually distinguished with glow rings

The new `timeline-viz` component handles all rendering while the page manages filters, state, and user interactions.

🤖 Generated with Claude Code