### PR TITLE
Add app shell with breadcrumbs, keyboard shortcuts, and document comparison

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { Switch, Route } from "wouter";
+import { Switch, Route, useLocation } from "wouter";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
@@ -7,12 +7,23 @@ import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { AppBreadcrumbs } from "@/components/breadcrumbs";
+import { useKeyboardShortcuts, shortcutsList } from "@/hooks/use-keyboard-shortcuts";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Kbd } from "@/components/kbd";
 import NotFound from "@/pages/not-found";
 import Dashboard from "@/pages/dashboard";
 import PeoplePage from "@/pages/people";
 import PersonDetail from "@/pages/person-detail";
 import DocumentsPage from "@/pages/documents";
 import DocumentDetailPage from "@/pages/document-detail";
+import DocumentComparePage from "@/pages/document-compare";
 import TimelinePage from "@/pages/timeline";
 import NetworkPage from "@/pages/network";
 import SearchPage from "@/pages/search";
@@ -24,6 +35,7 @@ function Router() {
       <Route path="/people" component={PeoplePage} />
       <Route path="/people/:id" component={PersonDetail} />
       <Route path="/documents" component={DocumentsPage} />
+      <Route path="/documents/compare" component={DocumentComparePage} />
       <Route path="/documents/:id" component={DocumentDetailPage} />
       <Route path="/timeline" component={TimelinePage} />
       <Route path="/network" component={NetworkPage} />
@@ -33,30 +45,61 @@ function Router() {
   );
 }
 
-function App() {
+function AppShell() {
+  const [, navigate] = useLocation();
+  const { showHelp, closeHelp } = useKeyboardShortcuts(navigate);
+
   const style = {
     "--sidebar-width": "16rem",
     "--sidebar-width-icon": "3rem",
   };
 
   return (
+    <SidebarProvider style={style as React.CSSProperties}>
+      <div className="flex h-screen w-full">
+        <AppSidebar />
+        <div className="flex flex-col flex-1 min-w-0">
+          <header className="flex items-center justify-between gap-2 p-2 border-b sticky top-0 z-50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+            <div className="flex items-center gap-3">
+              <SidebarTrigger data-testid="button-sidebar-toggle" />
+              <AppBreadcrumbs />
+            </div>
+            <ThemeToggle />
+          </header>
+          <main className="flex-1 overflow-auto">
+            <Router />
+          </main>
+        </div>
+      </div>
+
+      <Dialog open={showHelp} onOpenChange={(open) => !open && closeHelp()}>
+        <DialogContent className="sm:max-w-md" data-testid="dialog-keyboard-shortcuts">
+          <DialogHeader>
+            <DialogTitle>Keyboard Shortcuts</DialogTitle>
+            <DialogDescription>
+              Navigate quickly using these keyboard shortcuts.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-1 mt-2">
+            {shortcutsList.map((s) => (
+              <div key={s.keys} className="flex items-center justify-between py-1.5 px-1">
+                <span className="text-sm text-muted-foreground">{s.label}</span>
+                <Kbd keys={s.keys} />
+              </div>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </SidebarProvider>
+  );
+}
+
+function App() {
+  return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
         <TooltipProvider>
-          <SidebarProvider style={style as React.CSSProperties}>
-            <div className="flex h-screen w-full">
-              <AppSidebar />
-              <div className="flex flex-col flex-1 min-w-0">
-                <header className="flex items-center justify-between gap-2 p-2 border-b sticky top-0 z-50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-                  <SidebarTrigger data-testid="button-sidebar-toggle" />
-                  <ThemeToggle />
-                </header>
-                <main className="flex-1 overflow-auto">
-                  <Router />
-                </main>
-              </div>
-            </div>
-          </SidebarProvider>
+          <AppShell />
           <Toaster />
         </TooltipProvider>
       </ThemeProvider>

--- a/client/src/components/breadcrumbs.tsx
+++ b/client/src/components/breadcrumbs.tsx
@@ -1,0 +1,97 @@
+import { useLocation, Link } from "wouter";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Home } from "lucide-react";
+import type { Person, Document } from "@shared/schema";
+
+interface BreadcrumbSegment {
+  label: string;
+  href?: string;
+}
+
+const staticRoutes: Record<string, string> = {
+  people: "People",
+  documents: "Documents",
+  timeline: "Timeline",
+  network: "Network",
+  search: "Search",
+  compare: "Compare",
+};
+
+export function AppBreadcrumbs() {
+  const [location] = useLocation();
+
+  const segments = location.split("/").filter(Boolean);
+
+  // Detect if we're on a person or document detail page
+  const isPersonDetail = segments[0] === "people" && segments[1] && !isNaN(Number(segments[1]));
+  const isDocumentDetail = segments[0] === "documents" && segments[1] && segments[1] !== "compare" && !isNaN(Number(segments[1]));
+  const isDocumentCompare = segments[0] === "documents" && segments[1] === "compare";
+
+  const personId = isPersonDetail ? segments[1] : undefined;
+  const documentId = isDocumentDetail ? segments[1] : undefined;
+
+  const { data: person } = useQuery<Person>({
+    queryKey: ["/api/persons", personId],
+    enabled: !!personId,
+  });
+
+  const { data: document } = useQuery<Document>({
+    queryKey: ["/api/documents", documentId],
+    enabled: !!documentId,
+  });
+
+  if (location === "/") return null;
+
+  const crumbs: BreadcrumbSegment[] = [];
+
+  if (isPersonDetail) {
+    crumbs.push({ label: "People", href: "/people" });
+    crumbs.push({ label: person?.name || `Person #${personId}` });
+  } else if (isDocumentDetail) {
+    crumbs.push({ label: "Documents", href: "/documents" });
+    crumbs.push({ label: document?.title || `Document #${documentId}` });
+  } else if (isDocumentCompare) {
+    crumbs.push({ label: "Documents", href: "/documents" });
+    crumbs.push({ label: "Compare" });
+  } else {
+    // Static route like /people, /documents, /timeline, etc.
+    const label = staticRoutes[segments[0]] || segments[0];
+    crumbs.push({ label });
+  }
+
+  return (
+    <Breadcrumb data-testid="breadcrumbs">
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link href="/">
+              <Home className="w-3.5 h-3.5" />
+            </Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        {crumbs.map((crumb, i) => (
+          <span key={i} className="contents">
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              {crumb.href && i < crumbs.length - 1 ? (
+                <BreadcrumbLink asChild>
+                  <Link href={crumb.href}>{crumb.label}</Link>
+                </BreadcrumbLink>
+              ) : (
+                <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+              )}
+            </BreadcrumbItem>
+          </span>
+        ))}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/client/src/components/kbd.tsx
+++ b/client/src/components/kbd.tsx
@@ -1,0 +1,24 @@
+export function Kbd({ keys }: { keys: string }) {
+  const parts = keys.split(/([+ ])/);
+  return (
+    <span className="flex items-center gap-0.5">
+      {parts.map((part, i) => {
+        if (part === "+" || part === " ") {
+          return (
+            <span key={i} className="text-[10px] text-muted-foreground/60 mx-0.5">
+              {part === " " ? "then" : "+"}
+            </span>
+          );
+        }
+        return (
+          <kbd
+            key={i}
+            className="inline-flex items-center justify-center min-w-[1.5rem] h-6 px-1.5 text-[11px] font-mono font-medium rounded border bg-muted text-muted-foreground"
+          >
+            {part === "Cmd" ? "\u2318" : part === "Esc" ? "\u238b" : part}
+          </kbd>
+        );
+      })}
+    </span>
+  );
+}

--- a/client/src/hooks/use-keyboard-shortcuts.ts
+++ b/client/src/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,100 @@
+import { useEffect, useCallback, useState } from "react";
+
+export interface ShortcutDef {
+  keys: string;
+  label: string;
+  action: () => void;
+}
+
+export function useKeyboardShortcuts(navigate: (path: string) => void) {
+  const [showHelp, setShowHelp] = useState(false);
+  const [pendingG, setPendingG] = useState(false);
+
+  const closeHelp = useCallback(() => setShowHelp(false), []);
+
+  useEffect(() => {
+    let gTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function handler(e: KeyboardEvent) {
+      const target = e.target as HTMLElement;
+      const tag = target.tagName;
+      const isInput = tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable;
+
+      // Esc always works — close modals/help
+      if (e.key === "Escape") {
+        setShowHelp(false);
+        return;
+      }
+
+      // Cmd+K works everywhere
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        navigate("/search");
+        return;
+      }
+
+      // All other shortcuts only when not in a text field
+      if (isInput) return;
+
+      if (e.key === "/") {
+        e.preventDefault();
+        navigate("/search");
+        return;
+      }
+
+      if (e.key === "?") {
+        e.preventDefault();
+        setShowHelp((v) => !v);
+        return;
+      }
+
+      // "g" prefix shortcuts (two-key chords)
+      if (e.key === "g" && !pendingG) {
+        setPendingG(true);
+        gTimer = setTimeout(() => setPendingG(false), 800);
+        return;
+      }
+
+      if (pendingG) {
+        setPendingG(false);
+        if (gTimer) clearTimeout(gTimer);
+
+        const gMap: Record<string, string> = {
+          p: "/people",
+          d: "/documents",
+          t: "/timeline",
+          n: "/network",
+          h: "/",
+          s: "/search",
+        };
+
+        const dest = gMap[e.key];
+        if (dest) {
+          e.preventDefault();
+          navigate(dest);
+        }
+      }
+    }
+
+    window.addEventListener("keydown", handler);
+    return () => {
+      window.removeEventListener("keydown", handler);
+      if (gTimer) clearTimeout(gTimer);
+    };
+  }, [navigate, pendingG]);
+
+  return { showHelp, closeHelp };
+}
+
+export const shortcutsList: { keys: string; label: string }[] = [
+  { keys: "/", label: "Focus search" },
+  { keys: "Cmd+K", label: "Focus search (from anywhere)" },
+  { keys: "g p", label: "Go to People" },
+  { keys: "g d", label: "Go to Documents" },
+  { keys: "g t", label: "Go to Timeline" },
+  { keys: "g n", label: "Go to Network" },
+  { keys: "g h", label: "Go to Home" },
+  { keys: "g s", label: "Go to Search" },
+  { keys: "?", label: "Show keyboard shortcuts" },
+  { keys: "Esc", label: "Close modal / dialog" },
+];

--- a/client/src/pages/document-compare.tsx
+++ b/client/src/pages/document-compare.tsx
@@ -1,0 +1,272 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  ArrowLeft,
+  ArrowLeftRight,
+  FileText,
+  Check,
+  X,
+  Minus,
+} from "lucide-react";
+import type { Document } from "@shared/schema";
+
+interface DocumentWithPersons extends Document {
+  persons?: { id: number; name: string; mentionType: string }[];
+}
+
+interface DocsPage {
+  documents: Document[];
+  total: number;
+}
+
+function useDocumentsList() {
+  return useQuery<DocsPage>({
+    queryKey: ["/api/documents?page=1&limit=100"],
+  });
+}
+
+function useDocumentDetail(id: string | null) {
+  return useQuery<DocumentWithPersons>({
+    queryKey: ["/api/documents", id],
+    enabled: !!id,
+  });
+}
+
+function ComparisonRow({
+  label,
+  valueA,
+  valueB,
+}: {
+  label: string;
+  valueA: React.ReactNode;
+  valueB: React.ReactNode;
+}) {
+  const strA = typeof valueA === "string" ? valueA : "";
+  const strB = typeof valueB === "string" ? valueB : "";
+  const isDifferent = strA !== strB && strA !== "" && strB !== "";
+
+  return (
+    <div
+      className={`grid grid-cols-[140px_1fr_1fr] gap-3 py-2 px-3 rounded-sm ${
+        isDifferent ? "bg-yellow-500/5" : ""
+      }`}
+    >
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+      <span className="text-sm">{valueA || <Minus className="w-3 h-3 text-muted-foreground/40" />}</span>
+      <span className="text-sm">{valueB || <Minus className="w-3 h-3 text-muted-foreground/40" />}</span>
+    </div>
+  );
+}
+
+function BoolBadge({ value }: { value: boolean | null | undefined }) {
+  if (value === true) return <Badge variant="secondary" className="bg-destructive/10 text-destructive gap-1"><X className="w-3 h-3" /> Yes</Badge>;
+  if (value === false) return <Badge variant="secondary" className="bg-green-500/10 text-green-600 gap-1"><Check className="w-3 h-3" /> No</Badge>;
+  return <Minus className="w-3 h-3 text-muted-foreground/40" />;
+}
+
+export default function DocumentComparePage() {
+  const searchParams = new URLSearchParams(window.location.search);
+  const [docAId, setDocAId] = useState<string | null>(searchParams.get("a"));
+  const [docBId, setDocBId] = useState<string | null>(searchParams.get("b"));
+
+  const { data: docsPage, isLoading: listLoading } = useDocumentsList();
+  const documents = docsPage?.documents ?? [];
+  const { data: docA, isLoading: loadingA } = useDocumentDetail(docAId);
+  const { data: docB, isLoading: loadingB } = useDocumentDetail(docBId);
+
+  const isLoading = loadingA || loadingB;
+
+  return (
+    <div className="flex flex-col gap-6 p-6 max-w-6xl mx-auto w-full">
+      <Link href="/documents">
+        <Button variant="ghost" size="sm" className="gap-1 -ml-2" data-testid="button-back">
+          <ArrowLeft className="w-4 h-4" /> Documents
+        </Button>
+      </Link>
+
+      <div className="flex flex-col gap-2">
+        <h1 className="text-xl font-bold tracking-tight flex items-center gap-2" data-testid="text-compare-title">
+          <ArrowLeftRight className="w-5 h-5 text-primary" />
+          Compare Documents
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Select two documents to compare their metadata side by side.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="flex flex-col gap-2">
+          <label className="text-xs font-medium text-muted-foreground">Document A</label>
+          <Select value={docAId ?? ""} onValueChange={(v) => setDocAId(v || null)}>
+            <SelectTrigger data-testid="select-doc-a">
+              <SelectValue placeholder={listLoading ? "Loading..." : "Select document..."} />
+            </SelectTrigger>
+            <SelectContent>
+              {documents.map((d) => (
+                <SelectItem key={d.id} value={String(d.id)} disabled={String(d.id) === docBId}>
+                  <span className="truncate">{d.title}</span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-2">
+          <label className="text-xs font-medium text-muted-foreground">Document B</label>
+          <Select value={docBId ?? ""} onValueChange={(v) => setDocBId(v || null)}>
+            <SelectTrigger data-testid="select-doc-b">
+              <SelectValue placeholder={listLoading ? "Loading..." : "Select document..."} />
+            </SelectTrigger>
+            <SelectContent>
+              {documents.map((d) => (
+                <SelectItem key={d.id} value={String(d.id)} disabled={String(d.id) === docAId}>
+                  <span className="truncate">{d.title}</span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {(!docAId || !docBId) && (
+        <div className="flex flex-col items-center justify-center py-16 gap-3">
+          <FileText className="w-10 h-10 text-muted-foreground/20" />
+          <p className="text-sm text-muted-foreground">Select two documents above to compare.</p>
+        </div>
+      )}
+
+      {docAId && docBId && isLoading && (
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+      )}
+
+      {docA && docB && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <ArrowLeftRight className="w-4 h-4" /> Metadata Comparison
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-0">
+            {/* Header row */}
+            <div className="grid grid-cols-[140px_1fr_1fr] gap-3 py-2 px-3 border-b">
+              <span className="text-xs font-medium text-muted-foreground">Field</span>
+              <Link href={`/documents/${docA.id}`}>
+                <span className="text-xs font-semibold text-primary hover:underline truncate block">{docA.title}</span>
+              </Link>
+              <Link href={`/documents/${docB.id}`}>
+                <span className="text-xs font-semibold text-primary hover:underline truncate block">{docB.title}</span>
+              </Link>
+            </div>
+
+            <ComparisonRow label="Type" valueA={docA.documentType} valueB={docB.documentType} />
+            <ComparisonRow label="Data Set" valueA={docA.dataSet ?? ""} valueB={docB.dataSet ?? ""} />
+            <ComparisonRow label="Original Date" valueA={docA.dateOriginal ?? ""} valueB={docB.dateOriginal ?? ""} />
+            <ComparisonRow label="Published Date" valueA={docA.datePublished ?? ""} valueB={docB.datePublished ?? ""} />
+            <ComparisonRow label="Page Count" valueA={docA.pageCount ? String(docA.pageCount) : ""} valueB={docB.pageCount ? String(docB.pageCount) : ""} />
+            <ComparisonRow
+              label="Redacted"
+              valueA={<BoolBadge value={docA.isRedacted} />}
+              valueB={<BoolBadge value={docB.isRedacted} />}
+            />
+            <ComparisonRow label="Media Type" valueA={docA.mediaType ?? ""} valueB={docB.mediaType ?? ""} />
+            <ComparisonRow label="Processing" valueA={docA.processingStatus ?? ""} valueB={docB.processingStatus ?? ""} />
+            <ComparisonRow label="AI Analysis" valueA={docA.aiAnalysisStatus ?? ""} valueB={docB.aiAnalysisStatus ?? ""} />
+
+            {(docA.tags?.length || docB.tags?.length) && (
+              <ComparisonRow
+                label="Tags"
+                valueA={
+                  docA.tags?.length ? (
+                    <div className="flex flex-wrap gap-1">
+                      {docA.tags.map((t) => <Badge key={t} variant="outline" className="text-[10px]">{t}</Badge>)}
+                    </div>
+                  ) : ""
+                }
+                valueB={
+                  docB.tags?.length ? (
+                    <div className="flex flex-wrap gap-1">
+                      {docB.tags.map((t) => <Badge key={t} variant="outline" className="text-[10px]">{t}</Badge>)}
+                    </div>
+                  ) : ""
+                }
+              />
+            )}
+
+            <Separator className="my-2" />
+
+            {/* People mentioned comparison */}
+            <ComparisonRow
+              label="People Mentioned"
+              valueA={
+                docA.persons?.length ? (
+                  <div className="flex flex-wrap gap-1">
+                    {docA.persons.map((p) => {
+                      const inBoth = docB.persons?.some((bp) => bp.id === p.id);
+                      return (
+                        <Badge
+                          key={p.id}
+                          variant={inBoth ? "default" : "secondary"}
+                          className="text-[10px]"
+                        >
+                          {p.name}
+                        </Badge>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <span className="text-xs text-muted-foreground">None</span>
+                )
+              }
+              valueB={
+                docB.persons?.length ? (
+                  <div className="flex flex-wrap gap-1">
+                    {docB.persons.map((p) => {
+                      const inBoth = docA.persons?.some((ap) => ap.id === p.id);
+                      return (
+                        <Badge
+                          key={p.id}
+                          variant={inBoth ? "default" : "secondary"}
+                          className="text-[10px]"
+                        >
+                          {p.name}
+                        </Badge>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <span className="text-xs text-muted-foreground">None</span>
+                )
+              }
+            />
+
+            {docA.keyExcerpt || docB.keyExcerpt ? (
+              <>
+                <Separator className="my-2" />
+                <ComparisonRow
+                  label="Key Excerpt"
+                  valueA={docA.keyExcerpt ? <p className="text-xs italic text-muted-foreground">"{docA.keyExcerpt}"</p> : ""}
+                  valueB={docB.keyExcerpt ? <p className="text-xs italic text-muted-foreground">"{docB.keyExcerpt}"</p> : ""}
+                />
+              </>
+            ) : null}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/document-detail.tsx
+++ b/client/src/pages/document-detail.tsx
@@ -8,6 +8,7 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Separator } from "@/components/ui/separator";
 import {
   ArrowLeft,
+  ArrowLeftRight,
   FileText,
   Clock,
   ExternalLink,
@@ -67,11 +68,18 @@ export default function DocumentDetailPage() {
 
   return (
     <div className="flex flex-col gap-6 p-6 max-w-5xl mx-auto w-full">
-      <Link href="/documents">
-        <Button variant="ghost" size="sm" className="gap-1 -ml-2" data-testid="button-back">
-          <ArrowLeft className="w-4 h-4" /> Documents
-        </Button>
-      </Link>
+      <div className="flex items-center justify-between">
+        <Link href="/documents">
+          <Button variant="ghost" size="sm" className="gap-1 -ml-2" data-testid="button-back">
+            <ArrowLeft className="w-4 h-4" /> Documents
+          </Button>
+        </Link>
+        <Link href={`/documents/compare?a=${doc.id}`}>
+          <Button variant="outline" size="sm" className="gap-1" data-testid="button-compare">
+            <ArrowLeftRight className="w-4 h-4" /> Compare
+          </Button>
+        </Link>
+      </div>
 
       <div className="flex flex-col gap-4">
         <div className="flex items-start gap-4">


### PR DESCRIPTION
Implements three key UX features for the Epstein File Explorer:

- **Breadcrumb Navigation**: Route-aware breadcrumbs showing current path with dynamic entity names (e.g., "People > John Doe", "Documents > Court Filing #42"). Automatically fetches person/document titles and is hidden on the dashboard.
- **Global Keyboard Shortcuts**: `/` or `Cmd+K` to search, `g p/d/t/n/h/s` chord shortcuts for navigation, `?` to show help dialog, `Esc` to close modals. Help dialog displays all available shortcuts with styled key indicators.
- **Document Comparison**: New `/documents/compare` page for side-by-side metadata analysis. Select two documents via dropdown and compare type, dates, redaction status, tags, people mentioned, and excerpts. Compare button added to document detail pages.

Closes #7 #8 #10

🤖 Generated with Claude Code