### PR TITLE
Add pagination, URL filters, empty states, and skeleton improvements

### DIFF
--- a/client/src/hooks/use-url-filters.ts
+++ b/client/src/hooks/use-url-filters.ts
@@ -1,0 +1,58 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+
+type FilterConfig = Record<string, string>;
+
+/**
+ * Syncs filter state with URL search params.
+ * On mount, reads initial values from URL. On change, updates URL via replaceState.
+ */
+export function useUrlFilters<T extends FilterConfig>(defaults: T): [T, (key: keyof T, value: string) => void, () => void] {
+  const defaultsRef = useRef(defaults);
+
+  const readFromUrl = useCallback((): T => {
+    const params = new URLSearchParams(window.location.search);
+    const result = { ...defaultsRef.current };
+    for (const key of Object.keys(result)) {
+      const urlVal = params.get(key);
+      if (urlVal !== null) {
+        (result as FilterConfig)[key] = urlVal;
+      }
+    }
+    return result;
+  }, []);
+
+  const [filters, setFilters] = useState<T>(readFromUrl);
+
+  const writeToUrl = useCallback((updated: T) => {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(updated)) {
+      if (value && value !== defaultsRef.current[key]) {
+        params.set(key, value);
+      }
+    }
+    const search = params.toString();
+    const newUrl = window.location.pathname + (search ? `?${search}` : "");
+    window.history.replaceState(null, "", newUrl);
+  }, []);
+
+  const setFilter = useCallback((key: keyof T, value: string) => {
+    setFilters((prev) => {
+      const next = { ...prev, [key]: value };
+      writeToUrl(next);
+      return next;
+    });
+  }, [writeToUrl]);
+
+  const resetFilters = useCallback(() => {
+    const next = { ...defaultsRef.current };
+    setFilters(next);
+    writeToUrl(next);
+  }, [writeToUrl]);
+
+  // Read from URL on mount
+  useEffect(() => {
+    setFilters(readFromUrl());
+  }, [readFromUrl]);
+
+  return [filters, setFilter, resetFilters];
+}

--- a/client/src/pages/documents.tsx
+++ b/client/src/pages/documents.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
 import { Card, CardContent } from "@/components/ui/card";
@@ -15,11 +15,16 @@ import {
   Clock,
   Mail,
   Image,
-  ArrowUpDown,
   ExternalLink,
   Filter,
+  ChevronLeft,
+  ChevronRight,
+  X,
 } from "lucide-react";
+import { useUrlFilters } from "@/hooks/use-url-filters";
 import type { Document } from "@shared/schema";
+
+const ITEMS_PER_PAGE = 50;
 
 const typeIcons: Record<string, any> = {
   "flight log": Clock,
@@ -34,11 +39,43 @@ const typeIcons: Record<string, any> = {
   "witness statement": FileText,
 };
 
+const filterLabels: Record<string, string> = {
+  search: "Search",
+  type: "Type",
+  dataSet: "Data Set",
+  redacted: "Redaction",
+};
+
+function DocumentCardSkeleton({ index }: { index: number }) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="flex items-start gap-3" style={{ animationDelay: `${index * 75}ms` }}>
+          <Skeleton className="w-10 h-10 rounded-md shrink-0" />
+          <div className="flex flex-col gap-1.5 flex-1">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-2/3" />
+            <div className="flex gap-2 mt-1">
+              <Skeleton className="h-4 w-20 rounded-full" />
+              <Skeleton className="h-4 w-14 rounded-full" />
+              <Skeleton className="h-3 w-16" />
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 export default function DocumentsPage() {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [typeFilter, setTypeFilter] = useState("all");
-  const [dataSetFilter, setDataSetFilter] = useState("all");
-  const [redactedFilter, setRedactedFilter] = useState("all");
+  const [filters, setFilter, resetFilters] = useUrlFilters({
+    search: "",
+    type: "all",
+    dataSet: "all",
+    redacted: "all",
+    page: "1",
+  });
 
   const { data: documents, isLoading } = useQuery<Document[]>({
     queryKey: ["/api/documents"],
@@ -47,19 +84,39 @@ export default function DocumentsPage() {
   const documentTypes = ["all", ...Array.from(new Set(documents?.map((d) => d.documentType) || []))];
   const dataSets = ["all", ...Array.from(new Set(documents?.filter((d) => d.dataSet).map((d) => d.dataSet!) || []))].sort();
 
-  const filtered = documents?.filter((doc) => {
-    const matchesSearch =
-      doc.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      (doc.description || "").toLowerCase().includes(searchQuery.toLowerCase()) ||
-      (doc.keyExcerpt || "").toLowerCase().includes(searchQuery.toLowerCase());
-    const matchesType = typeFilter === "all" || doc.documentType === typeFilter;
-    const matchesDataSet = dataSetFilter === "all" || doc.dataSet === dataSetFilter;
-    const matchesRedacted =
-      redactedFilter === "all" ||
-      (redactedFilter === "redacted" && doc.isRedacted) ||
-      (redactedFilter === "unredacted" && !doc.isRedacted);
-    return matchesSearch && matchesType && matchesDataSet && matchesRedacted;
-  });
+  const filtered = useMemo(() => {
+    return documents?.filter((doc) => {
+      const matchesSearch =
+        !filters.search ||
+        doc.title.toLowerCase().includes(filters.search.toLowerCase()) ||
+        (doc.description || "").toLowerCase().includes(filters.search.toLowerCase()) ||
+        (doc.keyExcerpt || "").toLowerCase().includes(filters.search.toLowerCase());
+      const matchesType = filters.type === "all" || doc.documentType === filters.type;
+      const matchesDataSet = filters.dataSet === "all" || doc.dataSet === filters.dataSet;
+      const matchesRedacted =
+        filters.redacted === "all" ||
+        (filters.redacted === "redacted" && doc.isRedacted) ||
+        (filters.redacted === "unredacted" && !doc.isRedacted);
+      return matchesSearch && matchesType && matchesDataSet && matchesRedacted;
+    });
+  }, [documents, filters.search, filters.type, filters.dataSet, filters.redacted]);
+
+  const totalItems = filtered?.length || 0;
+  const totalPages = Math.max(1, Math.ceil(totalItems / ITEMS_PER_PAGE));
+  const currentPage = Math.min(Math.max(1, parseInt(filters.page) || 1), totalPages);
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const paginated = filtered?.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+
+  const activeFilters = Object.entries(filters).filter(
+    ([key, value]) =>
+      key !== "page" &&
+      value !== "" && value !== "all"
+  );
+
+  const hasActiveFilters = activeFilters.length > 0;
+
+  const goToPage = (page: number) => setFilter("page", String(page));
+  const resetPage = () => setFilter("page", "1");
 
   return (
     <div className="flex flex-col gap-6 p-6 max-w-7xl mx-auto w-full">
@@ -79,15 +136,18 @@ export default function DocumentsPage() {
           <Input
             type="search"
             placeholder="Search documents..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            value={filters.search}
+            onChange={(e) => {
+              setFilter("search", e.target.value);
+              resetPage();
+            }}
             className="pl-9"
             data-testid="input-document-search"
           />
         </div>
         <div className="flex items-center gap-2 flex-wrap">
           <Filter className="w-3 h-3 text-muted-foreground" />
-          <Select value={typeFilter} onValueChange={setTypeFilter}>
+          <Select value={filters.type} onValueChange={(v) => { setFilter("type", v); resetPage(); }}>
             <SelectTrigger className="w-40" data-testid="select-type-filter">
               <SelectValue placeholder="Type" />
             </SelectTrigger>
@@ -99,7 +159,7 @@ export default function DocumentsPage() {
               ))}
             </SelectContent>
           </Select>
-          <Select value={dataSetFilter} onValueChange={setDataSetFilter}>
+          <Select value={filters.dataSet} onValueChange={(v) => { setFilter("dataSet", v); resetPage(); }}>
             <SelectTrigger className="w-36" data-testid="select-dataset-filter">
               <SelectValue placeholder="Data Set" />
             </SelectTrigger>
@@ -111,7 +171,7 @@ export default function DocumentsPage() {
               ))}
             </SelectContent>
           </Select>
-          <Select value={redactedFilter} onValueChange={setRedactedFilter}>
+          <Select value={filters.redacted} onValueChange={(v) => { setFilter("redacted", v); resetPage(); }}>
             <SelectTrigger className="w-36" data-testid="select-redacted-filter">
               <SelectValue placeholder="Redaction" />
             </SelectTrigger>
@@ -121,16 +181,11 @@ export default function DocumentsPage() {
               <SelectItem value="unredacted">Unredacted</SelectItem>
             </SelectContent>
           </Select>
-          {(typeFilter !== "all" || dataSetFilter !== "all" || redactedFilter !== "all" || searchQuery) && (
+          {hasActiveFilters && (
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => {
-                setSearchQuery("");
-                setTypeFilter("all");
-                setDataSetFilter("all");
-                setRedactedFilter("all");
-              }}
+              onClick={resetFilters}
               data-testid="button-clear-filters"
             >
               Clear
@@ -142,20 +197,16 @@ export default function DocumentsPage() {
       {isLoading ? (
         <div className="flex flex-col gap-3">
           {Array.from({ length: 8 }).map((_, i) => (
-            <Card key={i}>
-              <CardContent className="p-4">
-                <Skeleton className="h-20 w-full" />
-              </CardContent>
-            </Card>
+            <DocumentCardSkeleton key={i} index={i} />
           ))}
         </div>
       ) : (
         <>
           <p className="text-xs text-muted-foreground">
-            Showing {filtered?.length || 0} of {documents?.length || 0} documents
+            Showing {totalItems === 0 ? 0 : startIndex + 1}–{Math.min(startIndex + ITEMS_PER_PAGE, totalItems)} of {totalItems} documents
           </p>
           <div className="flex flex-col gap-2">
-            {filtered?.map((doc) => {
+            {paginated?.map((doc) => {
               const Icon = typeIcons[doc.documentType] || FileText;
               return (
                 <Link key={doc.id} href={`/documents/${doc.id}`}>
@@ -222,22 +273,63 @@ export default function DocumentsPage() {
               );
             })}
           </div>
-          {filtered?.length === 0 && (
-            <div className="flex flex-col items-center justify-center py-16 gap-3">
+
+          {totalItems === 0 && (
+            <div className="flex flex-col items-center justify-center py-16 gap-4">
               <FileText className="w-10 h-10 text-muted-foreground/40" />
-              <p className="text-sm text-muted-foreground">No documents match your filters.</p>
+              <p className="text-sm text-muted-foreground text-center max-w-md">
+                No documents match these filters.
+                {filters.search && ` Try a different search term.`}
+                {filters.type !== "all" && ` Try removing the "${filters.type}" type filter.`}
+                {filters.redacted !== "all" && ` Try removing the "${filters.redacted}" filter.`}
+                {filters.dataSet !== "all" && ` Try removing the "Data Set ${filters.dataSet}" filter.`}
+              </p>
+              {activeFilters.length > 0 && (
+                <div className="flex items-center gap-2 flex-wrap justify-center">
+                  {activeFilters.map(([key, value]) => (
+                    <Button
+                      key={key}
+                      variant="outline"
+                      size="sm"
+                      className="h-7 gap-1 text-xs"
+                      onClick={() => setFilter(key, ["type", "dataSet", "redacted"].includes(key) ? "all" : "")}
+                    >
+                      {filterLabels[key] || key}: {value}
+                      <X className="w-3 h-3" />
+                    </Button>
+                  ))}
+                </div>
+              )}
+              <Button variant="outline" size="sm" onClick={resetFilters} data-testid="button-clear-filters-empty">
+                Clear all filters
+              </Button>
+            </div>
+          )}
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 pt-2">
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => {
-                  setSearchQuery("");
-                  setTypeFilter("all");
-                  setDataSetFilter("all");
-                  setRedactedFilter("all");
-                }}
-                data-testid="button-clear-filters-empty"
+                disabled={currentPage <= 1}
+                onClick={() => goToPage(currentPage - 1)}
+                data-testid="button-prev-page"
               >
-                Clear all filters
+                <ChevronLeft className="w-4 h-4 mr-1" />
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground px-3">
+                Page {currentPage} of {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={currentPage >= totalPages}
+                onClick={() => goToPage(currentPage + 1)}
+                data-testid="button-next-page"
+              >
+                Next
+                <ChevronRight className="w-4 h-4 ml-1" />
               </Button>
             </div>
           )}

--- a/client/src/pages/people.tsx
+++ b/client/src/pages/people.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
 import { Card, CardContent } from "@/components/ui/card";
@@ -8,8 +8,11 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Users, Search, FileText, Network, ArrowUpDown } from "lucide-react";
+import { Users, Search, FileText, Network, ArrowUpDown, ChevronLeft, ChevronRight, X } from "lucide-react";
+import { useUrlFilters } from "@/hooks/use-url-filters";
 import type { Person } from "@shared/schema";
+
+const ITEMS_PER_PAGE = 50;
 
 const categoryColors: Record<string, string> = {
   "key figure": "bg-destructive/10 text-destructive",
@@ -20,31 +23,79 @@ const categoryColors: Record<string, string> = {
   political: "bg-chart-5/10 text-chart-5",
 };
 
+const filterLabels: Record<string, string> = {
+  search: "Search",
+  category: "Category",
+  sort: "Sort",
+};
+
+function PersonCardSkeleton({ index }: { index: number }) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="flex items-start gap-3" style={{ animationDelay: `${index * 75}ms` }}>
+          <Skeleton className="w-12 h-12 rounded-full shrink-0" />
+          <div className="flex flex-col gap-1.5 flex-1">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-3 w-full" />
+            <div className="flex gap-2 mt-1">
+              <Skeleton className="h-4 w-16 rounded-full" />
+              <Skeleton className="h-3 w-10" />
+              <Skeleton className="h-3 w-10" />
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 export default function PeoplePage() {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [categoryFilter, setCategoryFilter] = useState("all");
-  const [sortBy, setSortBy] = useState("documentCount");
+  const [filters, setFilter, resetFilters] = useUrlFilters({
+    search: "",
+    category: "all",
+    sort: "documentCount",
+    page: "1",
+  });
 
   const { data: persons, isLoading } = useQuery<Person[]>({
     queryKey: ["/api/persons"],
   });
 
-  const filtered = persons
-    ?.filter((p) => {
-      const matchesSearch =
-        p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        (p.occupation || "").toLowerCase().includes(searchQuery.toLowerCase()) ||
-        (p.description || "").toLowerCase().includes(searchQuery.toLowerCase());
-      const matchesCategory = categoryFilter === "all" || p.category === categoryFilter;
-      return matchesSearch && matchesCategory;
-    })
-    .sort((a, b) => {
-      if (sortBy === "documentCount") return b.documentCount - a.documentCount;
-      if (sortBy === "connectionCount") return b.connectionCount - a.connectionCount;
-      return a.name.localeCompare(b.name);
-    });
+  const filtered = useMemo(() => {
+    return persons
+      ?.filter((p) => {
+        const matchesSearch =
+          !filters.search ||
+          p.name.toLowerCase().includes(filters.search.toLowerCase()) ||
+          (p.occupation || "").toLowerCase().includes(filters.search.toLowerCase()) ||
+          (p.description || "").toLowerCase().includes(filters.search.toLowerCase());
+        const matchesCategory = filters.category === "all" || p.category === filters.category;
+        return matchesSearch && matchesCategory;
+      })
+      .sort((a, b) => {
+        if (filters.sort === "documentCount") return b.documentCount - a.documentCount;
+        if (filters.sort === "connectionCount") return b.connectionCount - a.connectionCount;
+        return a.name.localeCompare(b.name);
+      });
+  }, [persons, filters.search, filters.category, filters.sort]);
 
   const categories = ["all", ...new Set(persons?.map((p) => p.category) || [])];
+
+  const totalItems = filtered?.length || 0;
+  const totalPages = Math.max(1, Math.ceil(totalItems / ITEMS_PER_PAGE));
+  const currentPage = Math.min(Math.max(1, parseInt(filters.page) || 1), totalPages);
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const paginated = filtered?.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+
+  const activeFilters = Object.entries(filters).filter(
+    ([key, value]) =>
+      key !== "page" && key !== "sort" &&
+      value !== "" && value !== "all"
+  );
+
+  const goToPage = (page: number) => setFilter("page", String(page));
 
   return (
     <div className="flex flex-col gap-6 p-6 max-w-7xl mx-auto w-full">
@@ -64,13 +115,16 @@ export default function PeoplePage() {
           <Input
             type="search"
             placeholder="Search by name, occupation..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            value={filters.search}
+            onChange={(e) => {
+              setFilter("search", e.target.value);
+              setFilter("page", "1");
+            }}
             className="pl-9"
             data-testid="input-people-search"
           />
         </div>
-        <Select value={categoryFilter} onValueChange={setCategoryFilter}>
+        <Select value={filters.category} onValueChange={(v) => { setFilter("category", v); setFilter("page", "1"); }}>
           <SelectTrigger className="w-full sm:w-40" data-testid="select-category-filter">
             <SelectValue placeholder="Category" />
           </SelectTrigger>
@@ -82,7 +136,7 @@ export default function PeoplePage() {
             ))}
           </SelectContent>
         </Select>
-        <Select value={sortBy} onValueChange={setSortBy}>
+        <Select value={filters.sort} onValueChange={(v) => setFilter("sort", v)}>
           <SelectTrigger className="w-full sm:w-44" data-testid="select-sort">
             <ArrowUpDown className="w-3 h-3 mr-1" />
             <SelectValue placeholder="Sort by" />
@@ -98,20 +152,18 @@ export default function PeoplePage() {
       {isLoading ? (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
           {Array.from({ length: 12 }).map((_, i) => (
-            <Card key={i}>
-              <CardContent className="p-4">
-                <Skeleton className="h-24 w-full" />
-              </CardContent>
-            </Card>
+            <PersonCardSkeleton key={i} index={i} />
           ))}
         </div>
       ) : (
         <>
-          <p className="text-xs text-muted-foreground">
-            Showing {filtered?.length || 0} of {persons?.length || 0} individuals
-          </p>
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-muted-foreground">
+              Showing {totalItems === 0 ? 0 : startIndex + 1}–{Math.min(startIndex + ITEMS_PER_PAGE, totalItems)} of {totalItems} individuals
+            </p>
+          </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-            {filtered?.map((person) => {
+            {paginated?.map((person) => {
               const initials = person.name
                 .split(" ")
                 .map((n) => n[0])
@@ -154,12 +206,61 @@ export default function PeoplePage() {
               );
             })}
           </div>
-          {filtered?.length === 0 && (
-            <div className="flex flex-col items-center justify-center py-16 gap-3">
+
+          {totalItems === 0 && (
+            <div className="flex flex-col items-center justify-center py-16 gap-4">
               <Users className="w-10 h-10 text-muted-foreground/40" />
-              <p className="text-sm text-muted-foreground">No individuals match your search.</p>
-              <Button variant="outline" size="sm" onClick={() => { setSearchQuery(""); setCategoryFilter("all"); }} data-testid="button-clear-filters">
-                Clear filters
+              <p className="text-sm text-muted-foreground text-center max-w-md">
+                No individuals match these filters.
+                {filters.search && ` Try a different search term.`}
+                {filters.category !== "all" && ` Try removing the "${filters.category}" category filter.`}
+              </p>
+              {activeFilters.length > 0 && (
+                <div className="flex items-center gap-2 flex-wrap justify-center">
+                  {activeFilters.map(([key, value]) => (
+                    <Button
+                      key={key}
+                      variant="outline"
+                      size="sm"
+                      className="h-7 gap-1 text-xs"
+                      onClick={() => setFilter(key, key === "category" ? "all" : "")}
+                    >
+                      {filterLabels[key] || key}: {value}
+                      <X className="w-3 h-3" />
+                    </Button>
+                  ))}
+                </div>
+              )}
+              <Button variant="outline" size="sm" onClick={resetFilters} data-testid="button-clear-filters">
+                Clear all filters
+              </Button>
+            </div>
+          )}
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 pt-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={currentPage <= 1}
+                onClick={() => goToPage(currentPage - 1)}
+                data-testid="button-prev-page"
+              >
+                <ChevronLeft className="w-4 h-4 mr-1" />
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground px-3">
+                Page {currentPage} of {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={currentPage >= totalPages}
+                onClick={() => goToPage(currentPage + 1)}
+                data-testid="button-next-page"
+              >
+                Next
+                <ChevronRight className="w-4 h-4 ml-1" />
               </Button>
             </div>
           )}


### PR DESCRIPTION
## Summary

Implement client-side pagination (50 items/page) with Previous/Next controls. Add URL parameter persistence for search, filters, and current page using a new `useUrlFilters` hook. Enhance empty states with contextual suggestions and removable filter chips. Improve skeleton loading with card-matched layouts and staggered animations.

## Changes

- **useUrlFilters hook**: Syncs filter state with URL search params via replaceState
- **people.tsx**: Pagination, URL filters (search/category/sort), contextual empty state, improved skeleton
- **documents.tsx**: Pagination, URL filters (search/type/dataSet/redacted), contextual empty state, improved skeleton

## Testing

Test pagination navigation, verify URL updates on filter changes, confirm page resets on new filters, check empty state suggestions for each filter combination.