### PR TITLE
Add person hover cards and export buttons

### DIFF
--- a/client/src/components/export-button.tsx
+++ b/client/src/components/export-button.tsx
@@ -1,0 +1,58 @@
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Download, FileSpreadsheet, FileJson } from "lucide-react";
+
+interface ExportButtonProps {
+  endpoint: string;
+  filename: string;
+  label?: string;
+}
+
+async function triggerDownload(endpoint: string, format: "csv" | "json", filename: string) {
+  const separator = endpoint.includes("?") ? "&" : "?";
+  const url = `${endpoint}${separator}format=${format}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error("Export failed");
+  const blob = await res.blob();
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = `${filename}.${format}`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(a.href);
+}
+
+export function ExportButton({ endpoint, filename, label = "Export" }: ExportButtonProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-1.5">
+          <Download className="w-3.5 h-3.5" />
+          {label}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          className="cursor-pointer gap-2"
+          onClick={() => triggerDownload(endpoint, "csv", filename)}
+        >
+          <FileSpreadsheet className="w-4 h-4" />
+          Export CSV
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="cursor-pointer gap-2"
+          onClick={() => triggerDownload(endpoint, "json", filename)}
+        >
+          <FileJson className="w-4 h-4" />
+          Export JSON
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/client/src/components/person-hover-card.tsx
+++ b/client/src/components/person-hover-card.tsx
@@ -1,0 +1,76 @@
+import { Link } from "wouter";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { FileText, Network, Briefcase, ArrowRight } from "lucide-react";
+import type { Person } from "@shared/schema";
+
+const categoryColors: Record<string, string> = {
+  "key figure": "bg-destructive/10 text-destructive",
+  associate: "bg-primary/10 text-primary",
+  victim: "bg-chart-4/10 text-chart-4",
+  witness: "bg-chart-3/10 text-chart-3",
+  legal: "bg-chart-2/10 text-chart-2",
+  political: "bg-chart-5/10 text-chart-5",
+};
+
+interface PersonHoverCardProps {
+  person: Pick<Person, "id" | "name" | "category" | "occupation" | "documentCount" | "connectionCount">;
+  children: React.ReactNode;
+}
+
+export function PersonHoverCard({ person, children }: PersonHoverCardProps) {
+  const initials = person.name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .slice(0, 2);
+
+  return (
+    <HoverCard openDelay={300} closeDelay={100}>
+      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+      <HoverCardContent className="w-72" side="top" align="start">
+        <div className="flex gap-3">
+          <Avatar className="w-10 h-10 border border-border shrink-0">
+            <AvatarFallback className="text-xs font-medium bg-muted">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+          <div className="flex flex-col gap-1.5 min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-semibold truncate">{person.name}</span>
+              <Badge
+                variant="secondary"
+                className={`text-[10px] shrink-0 ${categoryColors[person.category] || ""}`}
+              >
+                {person.category}
+              </Badge>
+            </div>
+            {person.occupation && (
+              <span className="text-xs text-muted-foreground flex items-center gap-1">
+                <Briefcase className="w-3 h-3 shrink-0" /> {person.occupation}
+              </span>
+            )}
+            <div className="flex items-center gap-3 text-xs text-muted-foreground">
+              <span className="flex items-center gap-1">
+                <FileText className="w-3 h-3" /> {person.documentCount} docs
+              </span>
+              <span className="flex items-center gap-1">
+                <Network className="w-3 h-3" /> {person.connectionCount} connections
+              </span>
+            </div>
+            <Link href={`/people/${person.id}`}>
+              <span className="text-xs text-primary flex items-center gap-1 mt-0.5 hover:underline cursor-pointer">
+                View Profile <ArrowRight className="w-3 h-3" />
+              </span>
+            </Link>
+          </div>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -16,6 +16,8 @@ import {
   AlertTriangle,
   Scale,
 } from "lucide-react";
+import { PersonHoverCard } from "@/components/person-hover-card";
+import { ExportButton } from "@/components/export-button";
 import type { Person, Document, TimelineEvent } from "@shared/schema";
 
 function StatCard({
@@ -78,7 +80,9 @@ function PersonCard({ person }: { person: Person }) {
               </AvatarFallback>
             </Avatar>
             <div className="flex flex-col gap-1 min-w-0 flex-1">
-              <span className="text-sm font-semibold truncate" data-testid={`text-person-name-${person.id}`}>{person.name}</span>
+              <PersonHoverCard person={person}>
+                <span className="text-sm font-semibold truncate hover:underline" data-testid={`text-person-name-${person.id}`}>{person.name}</span>
+              </PersonHoverCard>
               <span className="text-xs text-muted-foreground truncate">{person.occupation || person.role}</span>
               <div className="flex items-center gap-2 flex-wrap mt-1">
                 <Badge variant="secondary" className={`text-[10px] ${categoryColors[person.category] || ""}`}>
@@ -199,11 +203,14 @@ export default function Dashboard() {
               <TrendingUp className="w-4 h-4 text-primary" />
               Key Individuals
             </h2>
-            <Link href="/people">
-              <Button variant="ghost" size="sm" className="gap-1 text-xs" data-testid="button-view-all-people">
-                View all <ArrowRight className="w-3 h-3" />
-              </Button>
-            </Link>
+            <div className="flex items-center gap-2">
+              <ExportButton endpoint="/api/export/persons" filename="persons" label="Export" />
+              <Link href="/people">
+                <Button variant="ghost" size="sm" className="gap-1 text-xs" data-testid="button-view-all-people">
+                  View all <ArrowRight className="w-3 h-3" />
+                </Button>
+              </Link>
+            </div>
           </div>
           {peopleLoading ? (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">

--- a/client/src/pages/person-detail.tsx
+++ b/client/src/pages/person-detail.tsx
@@ -18,6 +18,8 @@ import {
   AlertTriangle,
   ExternalLink,
 } from "lucide-react";
+import { PersonHoverCard } from "@/components/person-hover-card";
+import { ExportButton } from "@/components/export-button";
 import type { Person, Document, Connection } from "@shared/schema";
 
 interface PersonDetail extends Person {
@@ -188,7 +190,15 @@ export default function PersonDetail() {
 
         <TabsContent value="connections" className="mt-4">
           {person.connections && person.connections.length > 0 ? (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="flex flex-col gap-3">
+              <div className="flex justify-end">
+                <ExportButton
+                  endpoint={`/api/export/persons`}
+                  filename={`${person.name.toLowerCase().replace(/\s+/g, "-")}-connections`}
+                  label="Export"
+                />
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               {person.connections.map((conn) => {
                 const connPerson = conn.person;
                 const connInitials = connPerson.name
@@ -206,7 +216,9 @@ export default function PersonDetail() {
                             <AvatarFallback className="text-xs font-medium bg-muted">{connInitials}</AvatarFallback>
                           </Avatar>
                           <div className="flex flex-col gap-1 min-w-0 flex-1">
-                            <span className="text-sm font-semibold">{connPerson.name}</span>
+                            <PersonHoverCard person={connPerson}>
+                              <span className="text-sm font-semibold hover:underline">{connPerson.name}</span>
+                            </PersonHoverCard>
                             <Badge variant="outline" className="text-[10px] w-fit">{conn.connectionType}</Badge>
                             {conn.description && (
                               <p className="text-xs text-muted-foreground mt-0.5">{conn.description}</p>
@@ -218,6 +230,7 @@ export default function PersonDetail() {
                   </Link>
                 );
               })}
+              </div>
             </div>
           ) : (
             <div className="flex flex-col items-center justify-center py-12 gap-2">


### PR DESCRIPTION
Implement reusable PersonHoverCard component using Radix HoverCard to preview
person information on hover. Add ExportButton component with CSV/JSON export options.
Both components integrate into person-detail and dashboard pages for seamless data
exploration and export workflows.

**Files added:**
- PersonHoverCard component with preview card showing name, category, occupation, doc/connection counts
- ExportButton component with dropdown export menu

**Files modified:**
- person-detail.tsx: wrap connection names with hover cards, add export button above connections list
- dashboard.tsx: wrap featured people names with hover cards, add export button in header

🤖 Generated with Claude Code