### PR TITLE
Fix suggestion clicks on Ask the Archive page

### DIFF
--- a/client/src/hooks/use-chat.ts
+++ b/client/src/hooks/use-chat.ts
@@ -3,7 +3,7 @@ import { queryClient } from "@/lib/queryClient";
 import type { ChatCitation } from "@shared/schema";
 
 interface UseChatReturn {
-  sendMessage: (content: string) => Promise<void>;
+  sendMessage: (content: string, overrideConversationId?: number) => Promise<void>;
   isStreaming: boolean;
   streamedContent: string;
   streamedCitations: ChatCitation[];
@@ -22,15 +22,16 @@ export function useChat(conversationId: number | null): UseChatReturn {
   }
 
   const sendMessage = useCallback(
-    async (content: string): Promise<void> => {
-      if (!conversationId || isStreaming) return;
+    async (content: string, overrideConversationId?: number): Promise<void> => {
+      const targetId = overrideConversationId ?? conversationId;
+      if (!targetId || isStreaming) return;
 
       setIsStreaming(true);
       setStreamedContent("");
       setStreamedCitations([]);
 
       const response = await fetch(
-        `/api/chat/conversations/${conversationId}/messages`,
+        `/api/chat/conversations/${targetId}/messages`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -86,7 +87,7 @@ export function useChat(conversationId: number | null): UseChatReturn {
                 queryKey: ["/api/chat/conversations"],
               });
               queryClient.invalidateQueries({
-                queryKey: [`/api/chat/conversations/${conversationId}`],
+                queryKey: [`/api/chat/conversations/${targetId}`],
               });
               return;
             }

--- a/client/src/pages/ask-archive.tsx
+++ b/client/src/pages/ask-archive.tsx
@@ -74,10 +74,7 @@ export default function AskArchivePage() {
     resetStream();
 
     if (initialMessage) {
-      // Small delay to let the state update
-      setTimeout(() => {
-        sendMessage(initialMessage);
-      }, 100);
+      sendMessage(initialMessage, conversation.id);
     }
   }
 


### PR DESCRIPTION
When clicking a suggestion, the message wasn't being sent because sendMessage used a stale conversationId from the closure. By passing the newly created conversation ID directly to sendMessage, we bypass the stale closure and send the initial message immediately.