### PR TITLE
Fix 6 UX issues in Epstein File Explorer dashboard (#24)

### DIFF
--- a/client/src/pages/ask-archive.tsx
+++ b/client/src/pages/ask-archive.tsx
@@ -161,15 +161,14 @@ export default function AskArchivePage() {
                 >
                   <MessageCircle className="w-4 h-4 shrink-0" />
                   <span className="truncate flex-1">{conv.title}</span>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-6 w-6 shrink-0 text-muted-foreground hover:text-destructive"
+                  <button
+                    className="h-6 w-6 shrink-0 inline-flex items-center justify-center rounded text-muted-foreground/70 hover:text-destructive transition-colors"
                     onClick={(e) => deleteConversation(conv.id, e)}
+                    aria-label="Delete conversation"
                     data-testid={`delete-conversation-${conv.id}`}
                   >
-                    <Trash2 className="w-3 h-3" />
-                  </Button>
+                    <Trash2 className="w-3.5 h-3.5" />
+                  </button>
                 </div>
               ))}
               {!loadingConversations && conversations.length === 0 && (

--- a/client/src/pages/documents.tsx
+++ b/client/src/pages/documents.tsx
@@ -38,7 +38,14 @@ function isNonDescriptiveTitle(title: string): boolean {
 function getDisplayTitle(doc: Document): string {
   if (!isNonDescriptiveTitle(doc.title)) return doc.title;
 
-  // Generate a better display title from available metadata
+  // Prefer AI-generated description if available
+  if (doc.description) {
+    return doc.description.length > 80
+      ? doc.description.slice(0, 77) + "..."
+      : doc.description;
+  }
+
+  // Fallback to type + set + date
   const typeName = doc.documentType
     ? doc.documentType.charAt(0).toUpperCase() + doc.documentType.slice(1)
     : "Document";

--- a/scripts/pipeline/run-pipeline.ts
+++ b/scripts/pipeline/run-pipeline.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { fileURLToPath } from "url";
 import { runAIAnalysis } from "./ai-analyzer";
 import {
+  deduplicatePersonsInDB,
   extractConnectionsFromDescriptions,
   importDownloadedFiles,
   loadAIResults,
@@ -52,6 +53,7 @@ const STAGES = [
   "import-downloads",
   "extract-connections",
   "update-counts",
+  "dedup-persons",
 ];
 
 function printUsage() {
@@ -229,6 +231,10 @@ async function runStage(stage: string, config: PipelineConfig): Promise<void> {
 
       case "update-counts":
         await updateDocumentCounts();
+        break;
+
+      case "dedup-persons":
+        await deduplicatePersonsInDB();
         break;
 
       default:

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -126,7 +126,7 @@ function normalizeName(name: string): string {
  * Check if two persons likely refer to the same individual.
  * Compares normalized names, aliases, and checks for substring/prefix matches.
  */
-function isSamePerson(a: Person, b: Person): boolean {
+export function isSamePerson(a: Person, b: Person): boolean {
   const normA = normalizeName(a.name);
   const normB = normalizeName(b.name);
 
@@ -146,6 +146,16 @@ function isSamePerson(a: Person, b: Person): boolean {
       const firstB = partsB[0];
       if (firstA.startsWith(firstB) || firstB.startsWith(firstA)) return true;
     }
+  }
+
+  // Single-name matching: "Epstein" matches "Jeffrey Epstein"
+  if (partsA.length === 1 && partsB.length >= 2) {
+    if (partsA[0] === partsB[partsB.length - 1]) return true;
+    if (partsB[0].startsWith(partsA[0]) || partsA[0].startsWith(partsB[0])) return true;
+  }
+  if (partsB.length === 1 && partsA.length >= 2) {
+    if (partsB[0] === partsA[partsA.length - 1]) return true;
+    if (partsA[0].startsWith(partsB[0]) || partsB[0].startsWith(partsA[0])) return true;
   }
 
   // Check against aliases
@@ -351,7 +361,9 @@ export class DatabaseStorage implements IStorage {
   }
 
   async getTimelineEvents(): Promise<TimelineEvent[]> {
-    return db.select().from(timelineEvents).orderBy(asc(timelineEvents.date));
+    return db.select().from(timelineEvents)
+      .where(sql`${timelineEvents.date} >= '1950'`)
+      .orderBy(asc(timelineEvents.date));
   }
 
   async createTimelineEvent(event: InsertTimelineEvent): Promise<TimelineEvent> {


### PR DESCRIPTION
## Summary

Addresses six UX issues identified in the dashboard:

1. **Document naming** - Shows meaningful titles instead of EFTA reference numbers
2. **Timeline filter** - Removes garbage events from pre-1950 and fixes "All Time" filter
3. **Person deduplication** - Network graph now consolidates duplicate person entries 
4. **Chat delete button** - Trash icon now visible in conversation sidebar
5. **PDF viewer** - Local file serving with R2 and DOJ proxy fallback
6. **Image browsing** - Data Set 10 photographs display correctly with error fallback

## Changes

- Enhanced `isSamePerson()` with single-name matching and export for pipeline
- Added `deduplicatePersonsInDB()` using Union-Find algorithm with FK remapping
- Improved document display logic with description preference fallback
- Added `/api/documents/:id/image` endpoint for photo serving
- Implemented path traversal protection and stream error handling
- Fixed CSS class conflicts and added accessibility labels

## Notes

This PR focuses on UX improvements. A follow-up will address production hardening for the dedup logic (transaction wrapping, duplicate junction row handling, timeline personIds remapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)