### PR TITLE
Fix /api/documents 500 error with server-side pagination

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -145,8 +145,8 @@ export default function Dashboard() {
     queryKey: ["/api/persons"],
   });
 
-  const { data: allDocs, isLoading: docsLoading } = useQuery<Document[]>({
-    queryKey: ["/api/documents"],
+  const { data: docsResult, isLoading: docsLoading } = useQuery<{ data: Document[]; total: number; page: number; totalPages: number }>({
+    queryKey: ["/api/documents?page=1&limit=5"],
   });
 
   const { data: allEvents, isLoading: eventsLoading } = useQuery<TimelineEvent[]>({
@@ -154,7 +154,7 @@ export default function Dashboard() {
   });
 
   const featuredPeople = allPeople?.slice(0, 6);
-  const recentDocs = allDocs?.slice(0, 5);
+  const recentDocs = docsResult?.data;
   const events = allEvents?.filter(e => e.significance >= 3).slice(-4);
 
   return (

--- a/client/src/pages/document-detail.tsx
+++ b/client/src/pages/document-detail.tsx
@@ -61,26 +61,20 @@ export default function DocumentDetailPage() {
     queryKey: ["/api/documents", params.id],
   });
 
-  const { data: allDocuments } = useQuery<Document[]>({
-    queryKey: ["/api/documents"],
+  const { data: adjacent } = useQuery<{ prev: number | null; next: number | null }>({
+    queryKey: [`/api/documents/${params.id}/adjacent`],
+    enabled: !!params.id,
   });
-
-  const docIndex = allDocuments?.findIndex((d) => d.id === doc?.id) ?? -1;
-  const prevDoc = docIndex > 0 ? allDocuments![docIndex - 1] : null;
-  const nextDoc =
-    docIndex >= 0 && docIndex < (allDocuments?.length ?? 0) - 1
-      ? allDocuments![docIndex + 1]
-      : null;
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
-      if (e.key === "ArrowLeft" && prevDoc) navigate(`/documents/${prevDoc.id}`);
-      if (e.key === "ArrowRight" && nextDoc) navigate(`/documents/${nextDoc.id}`);
+      if (e.key === "ArrowLeft" && adjacent?.prev) navigate(`/documents/${adjacent.prev}`);
+      if (e.key === "ArrowRight" && adjacent?.next) navigate(`/documents/${adjacent.next}`);
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [prevDoc, nextDoc, navigate]);
+  }, [adjacent, navigate]);
 
   if (isLoading) {
     return (
@@ -122,27 +116,24 @@ export default function DocumentDetailPage() {
             <ArrowLeft className="w-4 h-4" /> Documents
           </Button>
         </Link>
-        {allDocuments && docIndex >= 0 && (
+        {adjacent && (
           <div className="flex items-center gap-1">
             <Button
               variant="outline"
               size="icon"
               className="h-8 w-8"
-              disabled={!prevDoc}
-              onClick={() => prevDoc && navigate(`/documents/${prevDoc.id}`)}
+              disabled={!adjacent.prev}
+              onClick={() => adjacent.prev && navigate(`/documents/${adjacent.prev}`)}
               data-testid="button-prev-doc"
             >
               <ChevronLeft className="w-4 h-4" />
             </Button>
-            <span className="text-xs text-muted-foreground px-2 tabular-nums">
-              {docIndex + 1} of {allDocuments.length.toLocaleString()}
-            </span>
             <Button
               variant="outline"
               size="icon"
               className="h-8 w-8"
-              disabled={!nextDoc}
-              onClick={() => nextDoc && navigate(`/documents/${nextDoc.id}`)}
+              disabled={!adjacent.next}
+              onClick={() => adjacent.next && navigate(`/documents/${adjacent.next}`)}
               data-testid="button-next-doc"
             >
               <ChevronRight className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- Implement server-side pagination and filtering to handle 138K documents efficiently
- Add new endpoints: `/api/documents/filters` and `/api/documents/:id/adjacent`
- Update all pages to use paginated queries instead of client-side processing

## Changes
- **storage.ts**: New methods for filtered pagination, filter options, and adjacent document lookup
- **routes.ts**: Updated `/api/documents` to always paginate with filters; added 2 new endpoints
- **documents.tsx**: Switched to server-side pagination + filtering via query params
- **dashboard.tsx**: Now fetches only 5 recent docs instead of all 138K
- **document-detail.tsx**: Uses adjacent endpoint for prev/next nav instead of loading all docs

## Verification
✅ Build succeeds with no TypeScript errors
✅ Server-side filtering works with search, type, dataSet, and redacted parameters
✅ Filter dropdowns populated from database
✅ Document detail prev/next navigation works via adjacent endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)