### PR TITLE
Enhance network graph with advanced filtering and stats

### DIFF
--- a/client/src/components/network-graph.tsx
+++ b/client/src/components/network-graph.tsx
@@ -29,7 +29,7 @@ export interface GraphLink extends SimulationLinkDatum<GraphNode> {
   strength: number;
 }
 
-const categoryColors: Record<string, string> = {
+export const categoryColors: Record<string, string> = {
   "key figure": "hsl(0, 84%, 60%)",
   associate: "hsl(221, 83%, 53%)",
   victim: "hsl(43, 74%, 49%)",
@@ -55,6 +55,7 @@ interface NetworkGraphProps {
   searchQuery: string;
   selectedPersonId: number | null;
   onSelectPerson: (id: number | null) => void;
+  onReady?: () => void;
 }
 
 export default function NetworkGraph({
@@ -63,6 +64,7 @@ export default function NetworkGraph({
   searchQuery,
   selectedPersonId,
   onSelectPerson,
+  onReady,
 }: NetworkGraphProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -230,6 +232,8 @@ export default function NetworkGraph({
       });
 
     // Simulation
+    let tickCount = 0;
+    let readyFired = false;
     const simulation = forceSimulation<GraphNode>(nodes)
       .force(
         "link",
@@ -249,6 +253,12 @@ export default function NetworkGraph({
           .attr("y2", (d) => (d.target as GraphNode).y ?? 0);
 
         nodeGroup.attr("transform", (d) => `translate(${d.x ?? 0},${d.y ?? 0})`);
+
+        tickCount++;
+        if (!readyFired && tickCount >= 60) {
+          readyFired = true;
+          onReady?.();
+        }
       });
 
     simulationRef.current = simulation;

--- a/client/src/components/ui/slider.tsx
+++ b/client/src/components/ui/slider.tsx
@@ -19,6 +19,7 @@ const Slider = React.forwardRef<
       <SliderPrimitive.Range className="absolute h-full bg-primary" />
     </SliderPrimitive.Track>
     <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
   </SliderPrimitive.Root>
 ))
 Slider.displayName = SliderPrimitive.Root.displayName

--- a/client/src/pages/network.tsx
+++ b/client/src/pages/network.tsx
@@ -3,33 +3,40 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+  SheetDescription,
+} from "@/components/ui/sheet";
 import {
   Network,
   Search,
   X,
   ExternalLink,
   ChevronRight,
+  SlidersHorizontal,
+  Loader2,
+  FileText,
+  Users,
+  Link2,
 } from "lucide-react";
 import type { Person, Connection } from "@shared/schema";
-import NetworkGraph from "@/components/network-graph";
+import NetworkGraph, { categoryColors } from "@/components/network-graph";
 
 interface NetworkData {
   persons: Person[];
   connections: (Connection & { person1Name: string; person2Name: string })[];
+  timelineYearRange: [number, number];
+  personYears: Record<number, [number, number]>;
 }
-
-const categoryColors: Record<string, string> = {
-  "key figure": "hsl(0, 84%, 60%)",
-  associate: "hsl(221, 83%, 53%)",
-  victim: "hsl(43, 74%, 49%)",
-  witness: "hsl(173, 58%, 39%)",
-  legal: "hsl(262, 83%, 58%)",
-  political: "hsl(27, 87%, 57%)",
-};
 
 const connectionTypeColors: Record<string, string> = {
   "business associate": "bg-primary/10 text-primary",
@@ -42,42 +49,229 @@ const connectionTypeColors: Record<string, string> = {
   "victim testimony": "bg-chart-4/10 text-chart-4",
 };
 
+const ALL_CATEGORIES = ["key figure", "associate", "victim", "witness", "legal", "political"];
+
+function FilterControls({
+  searchQuery,
+  setSearchQuery,
+  activeCategories,
+  toggleCategory,
+  activeConnectionTypes,
+  toggleConnectionType,
+  connectionTypes,
+  keyword,
+  setKeyword,
+  timeRange,
+  setTimeRange,
+  yearRange,
+}: {
+  searchQuery: string;
+  setSearchQuery: (v: string) => void;
+  activeCategories: Set<string>;
+  toggleCategory: (cat: string) => void;
+  activeConnectionTypes: Set<string>;
+  toggleConnectionType: (type: string) => void;
+  connectionTypes: string[];
+  keyword: string;
+  setKeyword: (v: string) => void;
+  timeRange: [number, number] | null;
+  setTimeRange: (v: [number, number]) => void;
+  yearRange: [number, number] | null;
+}) {
+  return (
+    <div className="flex flex-col gap-5">
+      {/* Entity search */}
+      <div>
+        <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2 block">
+          Search People
+        </Label>
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
+          <Input
+            type="search"
+            placeholder="Search by name..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-8 h-8 text-sm"
+            data-testid="input-network-search"
+          />
+        </div>
+      </div>
+
+      {/* Category checkboxes */}
+      <div>
+        <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2 block">
+          Categories
+        </Label>
+        <div className="flex flex-col gap-1.5">
+          {ALL_CATEGORIES.map((cat) => (
+            <label key={cat} className="flex items-center gap-2 cursor-pointer py-0.5">
+              <Checkbox
+                checked={activeCategories.has(cat)}
+                onCheckedChange={() => toggleCategory(cat)}
+              />
+              <span
+                className="w-2 h-2 rounded-full shrink-0"
+                style={{ backgroundColor: categoryColors[cat] || categoryColors.associate }}
+              />
+              <span className="text-sm capitalize">{cat}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Connection type checkboxes */}
+      <div>
+        <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2 block">
+          Connection Types
+        </Label>
+        <div className="flex flex-col gap-1.5">
+          {connectionTypes.map((type) => (
+            <label key={type} className="flex items-center gap-2 cursor-pointer py-0.5">
+              <Checkbox
+                checked={activeConnectionTypes.has(type)}
+                onCheckedChange={() => toggleConnectionType(type)}
+              />
+              <span className="text-sm capitalize">{type}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Keyword filter */}
+      <div>
+        <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2 block">
+          Keyword Filter
+        </Label>
+        <Input
+          type="search"
+          placeholder="Filter by description..."
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          className="h-8 text-sm"
+        />
+      </div>
+
+      {/* Time range slider */}
+      {yearRange && timeRange && (
+        <div>
+          <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2 block">
+            Time Range
+          </Label>
+          <div className="px-1">
+            <Slider
+              min={yearRange[0]}
+              max={yearRange[1]}
+              step={1}
+              value={timeRange}
+              onValueChange={(v) => setTimeRange(v as [number, number])}
+            />
+          </div>
+          <div className="flex justify-between mt-1.5 text-xs text-muted-foreground">
+            <span>{timeRange[0]}</span>
+            <span>{timeRange[1]}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function NetworkPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedPerson, setSelectedPerson] = useState<number | null>(null);
-  const [connectionTypeFilter, setConnectionTypeFilter] = useState("all");
+  const [activeCategories, setActiveCategories] = useState<Set<string>>(new Set(ALL_CATEGORIES));
+  const [activeConnectionTypes, setActiveConnectionTypes] = useState<Set<string> | null>(null);
+  const [keyword, setKeyword] = useState("");
+  const [timeRange, setTimeRange] = useState<[number, number] | null>(null);
+  const [graphReady, setGraphReady] = useState(false);
+  const [filterSheetOpen, setFilterSheetOpen] = useState(false);
 
   const { data, isLoading } = useQuery<NetworkData>({
     queryKey: ["/api/network"],
   });
 
-  const connectionTypes = useMemo(
-    () => ["all", ...Array.from(new Set(data?.connections.map((c) => c.connectionType) || []))],
-    [data],
+  // Initialize connection type filter and time range when data arrives
+  const connectionTypes = useMemo(() => {
+    if (!data) return [];
+    return Array.from(new Set(data.connections.map((c) => c.connectionType)));
+  }, [data]);
+
+  // Initialize activeConnectionTypes when connectionTypes first loads
+  if (activeConnectionTypes === null && connectionTypes.length > 0) {
+    setActiveConnectionTypes(new Set(connectionTypes));
+  }
+
+  // Initialize time range when data loads
+  const yearRange = data?.timelineYearRange ?? null;
+  if (timeRange === null && yearRange) {
+    setTimeRange(yearRange);
+  }
+
+  const effectiveConnectionTypes = activeConnectionTypes ?? new Set(connectionTypes);
+
+  // Filter chain
+  // 1. Time range → filter persons
+  const timeFilteredPersons = useMemo(() => {
+    if (!data || !timeRange) return data?.persons ?? [];
+    return data.persons.filter((p) => {
+      const years = data.personYears[p.id];
+      if (!years) return true; // no timeline data = keep
+      return years[1] >= timeRange[0] && years[0] <= timeRange[1];
+    });
+  }, [data, timeRange]);
+
+  // 2. Category → filter persons
+  const categoryFilteredPersons = useMemo(() => {
+    return timeFilteredPersons.filter((p) => activeCategories.has(p.category));
+  }, [timeFilteredPersons, activeCategories]);
+
+  const categoryPersonIds = useMemo(
+    () => new Set(categoryFilteredPersons.map((p) => p.id)),
+    [categoryFilteredPersons],
   );
 
-  const filteredConnections = useMemo(() => {
+  // 3. Connection type → filter connections
+  const typeFilteredConnections = useMemo(() => {
     if (!data) return [];
-    return data.connections.filter((conn) => {
-      const matchesType = connectionTypeFilter === "all" || conn.connectionType === connectionTypeFilter;
-      const matchesSearch =
-        !searchQuery ||
-        conn.person1Name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        conn.person2Name.toLowerCase().includes(searchQuery.toLowerCase());
-      return matchesType && matchesSearch;
-    });
-  }, [data, connectionTypeFilter, searchQuery]);
+    return data.connections.filter(
+      (c) =>
+        effectiveConnectionTypes.has(c.connectionType) &&
+        categoryPersonIds.has(c.personId1) &&
+        categoryPersonIds.has(c.personId2),
+    );
+  }, [data, effectiveConnectionTypes, categoryPersonIds]);
 
-  // Persons involved in filtered connections (for graph)
+  // 4. Keyword → filter connections by description
+  const keywordFilteredConnections = useMemo(() => {
+    if (!keyword) return typeFilteredConnections;
+    const kw = keyword.toLowerCase();
+    return typeFilteredConnections.filter(
+      (c) => c.description && c.description.toLowerCase().includes(kw),
+    );
+  }, [typeFilteredConnections, keyword]);
+
+  // 5. Derive persons from remaining connections
+  const filteredConnections = keywordFilteredConnections;
   const graphPersons = useMemo(() => {
-    if (!data) return [];
     const ids = new Set<number>();
     filteredConnections.forEach((c) => {
       ids.add(c.personId1);
       ids.add(c.personId2);
     });
-    return data.persons.filter((p) => ids.has(p.id));
-  }, [data, filteredConnections]);
+    return categoryFilteredPersons.filter((p) => ids.has(p.id));
+  }, [categoryFilteredPersons, filteredConnections]);
+
+  // Document count from connections
+  const totalDocs = useMemo(() => {
+    const docIds = new Set<number>();
+    filteredConnections.forEach((c) => {
+      if (c.documentIds) {
+        for (const id of c.documentIds) docIds.add(id);
+      }
+    });
+    return docIds.size;
+  }, [filteredConnections]);
 
   // Selected person details
   const selectedPersonData = useMemo(() => {
@@ -96,6 +290,40 @@ export default function NetworkPage() {
     setSelectedPerson(id);
   }, []);
 
+  const handleGraphReady = useCallback(() => {
+    setGraphReady(true);
+  }, []);
+
+  const toggleCategory = useCallback((cat: string) => {
+    setActiveCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      return next;
+    });
+    setGraphReady(false);
+  }, []);
+
+  const toggleConnectionType = useCallback((type: string) => {
+    setActiveConnectionTypes((prev) => {
+      const next = new Set(prev ?? []);
+      if (next.has(type)) next.delete(type);
+      else next.add(type);
+      return next;
+    });
+    setGraphReady(false);
+  }, []);
+
+  const handleTimeRangeChange = useCallback((v: [number, number]) => {
+    setTimeRange(v);
+    setGraphReady(false);
+  }, []);
+
+  const handleKeywordChange = useCallback((v: string) => {
+    setKeyword(v);
+    setGraphReady(false);
+  }, []);
+
   // Mobile list data: persons sorted by connection count
   const mobileListPersons = useMemo(() => {
     const counts: Record<number, number> = {};
@@ -108,68 +336,113 @@ export default function NetworkPage() {
       .sort((a, b) => b.connCount - a.connCount);
   }, [graphPersons, filteredConnections]);
 
+  const filterProps = {
+    searchQuery,
+    setSearchQuery,
+    activeCategories,
+    toggleCategory,
+    activeConnectionTypes: effectiveConnectionTypes,
+    toggleConnectionType,
+    connectionTypes,
+    keyword,
+    setKeyword: handleKeywordChange,
+    timeRange,
+    setTimeRange: handleTimeRangeChange,
+    yearRange,
+  };
+
   return (
     <div className="flex flex-col gap-4 p-4 md:p-6 w-full h-full">
       {/* Header */}
       <div className="flex flex-col gap-2">
-        <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2" data-testid="text-network-title">
-          <Network className="w-6 h-6 text-primary" />
-          Relationship Network
-        </h1>
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2" data-testid="text-network-title">
+            <Network className="w-6 h-6 text-primary" />
+            Relationship Network
+          </h1>
+
+          {/* Mobile filter button */}
+          <Sheet open={filterSheetOpen} onOpenChange={setFilterSheetOpen}>
+            <SheetTrigger asChild>
+              <Button variant="outline" size="sm" className="md:hidden">
+                <SlidersHorizontal className="w-4 h-4 mr-1.5" />
+                Filters
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="left" className="w-[280px] overflow-y-auto">
+              <SheetHeader>
+                <SheetTitle>Filters</SheetTitle>
+                <SheetDescription>Refine the network graph</SheetDescription>
+              </SheetHeader>
+              <div className="mt-4">
+                <FilterControls {...filterProps} />
+              </div>
+            </SheetContent>
+          </Sheet>
+        </div>
         <p className="text-sm text-muted-foreground">
           Interactive force-directed graph of connections between individuals. Click nodes to explore relationships.
         </p>
       </div>
 
-      {/* Controls */}
-      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
-        <div className="relative flex-1 w-full sm:max-w-sm">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-          <Input
-            type="search"
-            placeholder="Search people..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-9"
-            data-testid="input-network-search"
-          />
+      {/* Stats bar */}
+      {!isLoading && data && (
+        <div className="flex items-center gap-3 flex-wrap">
+          <Badge variant="secondary" className="gap-1.5 text-xs font-normal">
+            <Users className="w-3 h-3" />
+            {graphPersons.length} People
+          </Badge>
+          <Badge variant="secondary" className="gap-1.5 text-xs font-normal">
+            <Link2 className="w-3 h-3" />
+            {filteredConnections.length} Connections
+          </Badge>
+          <Badge variant="secondary" className="gap-1.5 text-xs font-normal">
+            <FileText className="w-3 h-3" />
+            {totalDocs} Documents
+          </Badge>
+          {selectedPerson && (
+            <Button variant="ghost" size="sm" onClick={() => setSelectedPerson(null)} className="ml-auto h-7 text-xs" data-testid="button-clear-person">
+              <X className="w-3 h-3 mr-1" />
+              Clear selection
+            </Button>
+          )}
         </div>
-        <Select value={connectionTypeFilter} onValueChange={setConnectionTypeFilter}>
-          <SelectTrigger className="w-full sm:w-48" data-testid="select-connection-type">
-            <SelectValue placeholder="Connection Type" />
-          </SelectTrigger>
-          <SelectContent>
-            {connectionTypes.map((type) => (
-              <SelectItem key={type} value={type}>
-                {type === "all" ? "All Types" : type.charAt(0).toUpperCase() + type.slice(1)}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        {selectedPerson && (
-          <Button variant="ghost" size="sm" onClick={() => setSelectedPerson(null)} data-testid="button-clear-person">
-            <X className="w-3 h-3 mr-1" />
-            Clear selection
-          </Button>
-        )}
-        <span className="text-xs text-muted-foreground ml-auto hidden sm:block">
-          {graphPersons.length} people · {filteredConnections.length} connections
-        </span>
-      </div>
+      )}
 
       {isLoading ? (
-        <Skeleton className="flex-1 min-h-[500px] w-full rounded-lg" />
+        <div className="flex-1 min-h-[500px] w-full rounded-lg border border-border bg-card flex items-center justify-center">
+          <div className="flex flex-col items-center gap-3">
+            <Loader2 className="w-8 h-8 animate-spin text-primary" />
+            <span className="text-sm text-muted-foreground">Loading network data...</span>
+          </div>
+        </div>
       ) : (
         <>
-          {/* Desktop: Graph + optional sidebar */}
+          {/* Desktop: Filter sidebar + Graph + optional detail sidebar */}
           <div className="hidden md:flex flex-1 gap-4 min-h-[500px]">
-            <div className={`flex-1 transition-all ${selectedPersonData ? "md:w-2/3" : "w-full"}`}>
+            {/* Filter sidebar */}
+            <div className="w-[240px] shrink-0 border border-border rounded-lg bg-card p-4 overflow-y-auto max-h-[calc(100vh-260px)]">
+              <FilterControls {...filterProps} />
+            </div>
+
+            {/* Graph area */}
+            <div className={`flex-1 relative transition-all ${selectedPersonData ? "md:w-2/3" : "w-full"}`}>
+              {/* Spinner overlay while graph computes */}
+              {!graphReady && (
+                <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/60 rounded-lg">
+                  <div className="flex flex-col items-center gap-3">
+                    <Loader2 className="w-8 h-8 animate-spin text-primary" />
+                    <span className="text-sm text-muted-foreground">Computing layout...</span>
+                  </div>
+                </div>
+              )}
               <NetworkGraph
                 persons={graphPersons}
                 connections={filteredConnections}
                 searchQuery={searchQuery}
                 selectedPersonId={selectedPerson}
                 onSelectPerson={handleSelectPerson}
+                onReady={handleGraphReady}
               />
             </div>
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -35,7 +35,7 @@ export interface IStorage {
   createTimelineEvent(event: InsertTimelineEvent): Promise<TimelineEvent>;
 
   getStats(): Promise<{ personCount: number; documentCount: number; connectionCount: number; eventCount: number }>;
-  getNetworkData(): Promise<{ persons: Person[]; connections: any[] }>;
+  getNetworkData(): Promise<{ persons: Person[]; connections: any[]; timelineYearRange: [number, number]; personYears: Record<number, [number, number]> }>;
   search(query: string): Promise<{ persons: Person[]; documents: Document[]; events: TimelineEvent[] }>;
 
   getPersonsPaginated(page: number, limit: number): Promise<{ data: Person[]; total: number; page: number; totalPages: number }>;
@@ -583,7 +583,36 @@ export class DatabaseStorage implements IStorage {
       });
     }
 
-    return { persons: allPersons, connections: enrichedConnections };
+    // Compute timeline year ranges for the time slider
+    const [yearRangeRow] = await db.select({
+      minDate: sql<string>`min(${timelineEvents.date})`,
+      maxDate: sql<string>`max(${timelineEvents.date})`,
+    }).from(timelineEvents);
+
+    const minYear = yearRangeRow?.minDate ? parseInt(yearRangeRow.minDate.slice(0, 4)) || 1990 : 1990;
+    const maxYear = yearRangeRow?.maxDate ? parseInt(yearRangeRow.maxDate.slice(0, 4)) || 2025 : 2025;
+
+    // Per-person year ranges from timeline events
+    const personYearRows = await db.select({
+      pid: sql<number>`unnest(${timelineEvents.personIds})`,
+      minDate: sql<string>`min(${timelineEvents.date})`,
+      maxDate: sql<string>`max(${timelineEvents.date})`,
+    }).from(timelineEvents)
+      .groupBy(sql`unnest(${timelineEvents.personIds})`);
+
+    const personYears: Record<number, [number, number]> = {};
+    for (const row of personYearRows) {
+      const earliest = parseInt(row.minDate.slice(0, 4)) || minYear;
+      const latest = parseInt(row.maxDate.slice(0, 4)) || maxYear;
+      personYears[row.pid] = [earliest, latest];
+    }
+
+    return {
+      persons: allPersons,
+      connections: enrichedConnections,
+      timelineYearRange: [minYear, maxYear] as [number, number],
+      personYears,
+    };
   }
 
   async search(query: string) {


### PR DESCRIPTION
## Summary

Enhanced the network graph page with a professional filtering experience inspired by similar graph platforms. Added a left-side filter sidebar on desktop with entity search, category/connection-type checkboxes, keyword filter, and dual-thumb time range slider. Stats bar shows live-updated counts. Mobile uses a sheet-based filter drawer. Backend extends the network API with timeline year ranges for client-side filtering.

## Changes

- **UI/UX**: Loading spinner overlays, stats bar with icon badges, responsive filter sidebar
- **Filtering**: Complete client-side filter chain (time → category → type → keyword → persons)
- **Backend**: Timeline year range computation for time slider bounds
- **Components**: Fixed Slider to support dual-thumb range selection
- **Mobile**: Sheet-based filter drawer preserves list view

## Verification

- ✅ Build passes
- ✅ /api/network returns timelineYearRange and personYears
- ✅ Network page shows loading spinner, stats bar, and filter controls
- ✅ Category/connection type checkboxes filter graph
- ✅ Time slider bounds match timeline data
- ✅ Mobile filter sheet works
- ✅ Dual-thumb slider functions correctly

🤖 Generated with Claude Code