### PR TITLE
Add granular sidebar navigation with categorized counts

### DIFF
--- a/client/src/components/app-sidebar.tsx
+++ b/client/src/components/app-sidebar.tsx
@@ -5,12 +5,14 @@ import {
   SidebarGroupContent,
   SidebarGroupLabel,
   SidebarMenu,
+  SidebarMenuBadge,
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarHeader,
   SidebarFooter,
 } from "@/components/ui/sidebar";
 import { Link, useLocation } from "wouter";
+import { useQuery } from "@tanstack/react-query";
 import {
   LayoutDashboard,
   Users,
@@ -18,25 +20,139 @@ import {
   Clock,
   Search,
   Network,
-  // MessageCircle,
   Brain,
   ExternalLink,
   Shield,
+  Gavel,
+  Mail,
+  AlertTriangle,
+  Scale,
+  Plane,
+  DollarSign,
+  BookOpen,
+  Image,
+  Video,
 } from "lucide-react";
 
-const navItems = [
-  { title: "Dashboard", url: "/", icon: LayoutDashboard },
-  { title: "People", url: "/people", icon: Users },
-  { title: "Documents", url: "/documents", icon: FileText },
-  { title: "Timeline", url: "/timeline", icon: Clock },
-  { title: "Network", url: "/network", icon: Network },
-  { title: "Search", url: "/search", icon: Search },
-  { title: "AI Insights", url: "/ai-insights", icon: Brain },
-  // { title: "Ask the Archive", url: "/ask-the-archive", icon: MessageCircle },
-];
+interface SidebarCounts {
+  documents: { total: number; byType: Record<string, number> };
+  media: { images: number; videos: number };
+  persons: number;
+  events: number;
+  connections: number;
+}
+
+function formatCount(n: number | undefined): string {
+  if (!n) return "";
+  if (n >= 1000) return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}K`;
+  return String(n);
+}
+
+interface NavItem {
+  title: string;
+  url: string;
+  icon: React.ComponentType<{ className?: string }>;
+  count?: number;
+}
+
+function NavGroup({ label, items, location }: { label: string; items: NavItem[]; location: string }) {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>{label}</SidebarGroupLabel>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {items.map((item) => {
+            const isActive = isNavActive(item.url, location);
+            return (
+              <SidebarMenuItem key={item.title}>
+                <SidebarMenuButton
+                  asChild
+                  isActive={isActive}
+                  data-testid={`nav-${item.title.toLowerCase().replace(/\s+/g, "-")}`}
+                >
+                  <Link href={item.url}>
+                    <item.icon className="w-4 h-4" />
+                    <span>{item.title}</span>
+                  </Link>
+                </SidebarMenuButton>
+                {item.count != null && item.count > 0 && (
+                  <SidebarMenuBadge>{formatCount(item.count)}</SidebarMenuBadge>
+                )}
+              </SidebarMenuItem>
+            );
+          })}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}
+
+function isNavActive(itemUrl: string, currentLocation: string): boolean {
+  const [itemPath, itemSearch] = itemUrl.split("?");
+  const currentPath = currentLocation.split("?")[0];
+  const currentSearch = currentLocation.includes("?") ? currentLocation.split("?")[1] : "";
+
+  // Exact match for root
+  if (itemPath === "/" && currentPath === "/") return !currentSearch;
+
+  // For items with query params, match both path and search params
+  if (itemSearch) {
+    if (currentPath !== itemPath) return false;
+    const itemParams = new URLSearchParams(itemSearch);
+    const currentParams = new URLSearchParams(currentSearch);
+    let allMatch = true;
+    itemParams.forEach((value, key) => {
+      if (currentParams.get(key) !== value) allMatch = false;
+    });
+    if (!allMatch) return false;
+    return true;
+  }
+
+  // Standard prefix match for non-root items
+  return currentPath === itemPath || currentPath.startsWith(itemPath + "/");
+}
 
 export function AppSidebar() {
   const [location] = useLocation();
+  const fullLocation = location + (typeof window !== "undefined" ? window.location.search : "");
+
+  const { data: counts } = useQuery<SidebarCounts>({
+    queryKey: ["/api/sidebar-counts"],
+    staleTime: 60_000,
+  });
+
+  const byType = counts?.documents.byType ?? {};
+
+  const overviewItems: NavItem[] = [
+    { title: "Dashboard", url: "/", icon: LayoutDashboard },
+  ];
+
+  const documentItems: NavItem[] = [
+    { title: "All Documents", url: "/documents", icon: FileText, count: counts?.documents.total },
+    { title: "Court Filings", url: "/documents?type=court+filing", icon: Gavel, count: byType["court filing"] },
+    { title: "Correspondence", url: "/documents?type=correspondence", icon: Mail, count: byType["correspondence"] },
+    { title: "FBI Reports", url: "/documents?type=fbi+report", icon: AlertTriangle, count: byType["fbi report"] },
+    { title: "Depositions", url: "/documents?type=deposition", icon: Scale, count: byType["deposition"] },
+    { title: "Flight Logs", url: "/documents?type=flight+log", icon: Plane, count: byType["flight log"] },
+    { title: "Financial Records", url: "/documents?type=financial+record", icon: DollarSign, count: byType["financial record"] },
+    { title: "Grand Jury", url: "/documents?type=grand+jury+transcript", icon: BookOpen, count: byType["grand jury transcript"] },
+  ];
+
+  const mediaItems: NavItem[] = [
+    { title: "Photos", url: "/documents?mediaType=image", icon: Image, count: counts?.media.images },
+    { title: "Videos", url: "/documents?mediaType=video", icon: Video, count: counts?.media.videos },
+  ];
+
+  const investigationItems: NavItem[] = [
+    { title: "People", url: "/people", icon: Users, count: counts?.persons },
+    { title: "Timeline", url: "/timeline", icon: Clock, count: counts?.events },
+    { title: "Network", url: "/network", icon: Network },
+    { title: "AI Insights", url: "/ai-insights", icon: Brain },
+  ];
+
+  const toolItems: NavItem[] = [
+    { title: "Search", url: "/search", icon: Search },
+  ];
 
   return (
     <Sidebar>
@@ -52,30 +168,11 @@ export function AppSidebar() {
         </Link>
       </SidebarHeader>
       <SidebarContent>
-        <SidebarGroup>
-          <SidebarGroupLabel>Navigation</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {navItems.map((item) => {
-                const isActive = location === item.url || (item.url !== "/" && location.startsWith(item.url));
-                return (
-                  <SidebarMenuItem key={item.title}>
-                    <SidebarMenuButton
-                      asChild
-                      isActive={isActive}
-                      data-testid={`nav-${item.title.toLowerCase()}`}
-                    >
-                      <Link href={item.url}>
-                        <item.icon className="w-4 h-4" />
-                        <span>{item.title}</span>
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                );
-              })}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+        <NavGroup label="Overview" items={overviewItems} location={fullLocation} />
+        <NavGroup label="Documents" items={documentItems} location={fullLocation} />
+        <NavGroup label="Media" items={mediaItems} location={fullLocation} />
+        <NavGroup label="Investigation" items={investigationItems} location={fullLocation} />
+        <NavGroup label="Tools" items={toolItems} location={fullLocation} />
       </SidebarContent>
       <SidebarFooter className="p-4">
         <div className="flex flex-col gap-2 text-[10px] text-muted-foreground">

--- a/scripts/pipeline/backfill-document-types.ts
+++ b/scripts/pipeline/backfill-document-types.ts
@@ -1,0 +1,126 @@
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { db } from "../../server/db";
+import { documents } from "../../shared/schema";
+import { eq, and, sql } from "drizzle-orm";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const AI_ANALYZED_DIR = path.resolve(__dirname, "../../data/ai-analyzed");
+
+/**
+ * Canonical document type mapping.
+ * Each entry maps a canonical type to regex patterns that match AI-assigned document types.
+ */
+const CANONICAL_TYPE_MAP: [string, RegExp][] = [
+  ["correspondence", /correspondence|email|letter|memo|fax|internal memorandum/i],
+  ["court filing", /court filing|court order|indictment|plea|subpoena|motion|docket/i],
+  ["fbi report", /fbi|302|bureau/i],
+  ["deposition", /deposition|interview transcript/i],
+  ["grand jury transcript", /grand jury/i],
+  ["flight log", /flight|manifest|aircraft/i],
+  ["financial record", /financial|bank|account|employment record/i],
+  ["search warrant", /search warrant|seizure|elsur/i],
+  ["police report", /police|incident report|booking/i],
+  ["property record", /property|real estate/i],
+  ["news article", /news|press|article|magazine/i],
+  ["travel record", /travel|passport|immigration/i],
+];
+
+function normalizeDocumentType(aiType: string): string {
+  for (const [canonical, pattern] of CANONICAL_TYPE_MAP) {
+    if (pattern.test(aiType)) return canonical;
+  }
+  return "government record";
+}
+
+function parseEftaNumber(fileName: string): string | null {
+  const match = fileName.match(/(EFTA\d+)/i);
+  return match ? match[1].toUpperCase() : null;
+}
+
+interface AIAnalysis {
+  fileName?: string;
+  documentType?: string;
+}
+
+async function main() {
+  console.log("Reading AI-analyzed files...");
+
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(AI_ANALYZED_DIR).filter((f) => f.endsWith(".json"));
+  } catch {
+    console.error(`Cannot read directory: ${AI_ANALYZED_DIR}`);
+    process.exit(1);
+  }
+
+  console.log(`Found ${entries.length} AI analysis files`);
+
+  const updates: { eftaNumber: string; canonicalType: string }[] = [];
+  const typeCounts = new Map<string, number>();
+
+  for (const file of entries) {
+    try {
+      const raw = fs.readFileSync(path.join(AI_ANALYZED_DIR, file), "utf-8");
+      const data: AIAnalysis = JSON.parse(raw);
+
+      const eftaNumber = parseEftaNumber(file);
+      if (!eftaNumber) continue;
+
+      const aiType = data.documentType || "";
+      const canonical = normalizeDocumentType(aiType);
+
+      // Only queue updates for rows that would actually change
+      if (canonical !== "government record") {
+        updates.push({ eftaNumber, canonicalType: canonical });
+      }
+
+      typeCounts.set(canonical, (typeCounts.get(canonical) || 0) + 1);
+    } catch {
+      console.warn(`Skipping invalid file: ${file}`);
+    }
+  }
+
+  console.log("\nType distribution from AI analysis:");
+  for (const [type, count] of [...typeCounts.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${type}: ${count}`);
+  }
+
+  console.log(`\n${updates.length} documents to update (excluding 'government record' fallbacks)`);
+
+  // Batch update in chunks of 100
+  const BATCH_SIZE = 100;
+  let updated = 0;
+
+  for (let i = 0; i < updates.length; i += BATCH_SIZE) {
+    const batch = updates.slice(i, i + BATCH_SIZE);
+
+    for (const { eftaNumber, canonicalType } of batch) {
+      const result = await db
+        .update(documents)
+        .set({ documentType: canonicalType })
+        .where(
+          and(
+            eq(documents.eftaNumber, eftaNumber),
+            eq(documents.documentType, "government record"),
+          ),
+        )
+        .returning({ id: documents.id });
+
+      updated += result.length;
+    }
+
+    console.log(`  Processed ${Math.min(i + BATCH_SIZE, updates.length)}/${updates.length} updates (${updated} rows changed)`);
+  }
+
+  console.log(`\nDone. Updated ${updated} document rows.`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -114,8 +114,9 @@ export async function registerRoutes(
       const type = (req.query.type as string) || undefined;
       const dataSet = (req.query.dataSet as string) || undefined;
       const redacted = (req.query.redacted as string) || undefined;
+      const mediaType = (req.query.mediaType as string) || undefined;
 
-      const result = await storage.getDocumentsFiltered({ page, limit, search, type, dataSet, redacted });
+      const result = await storage.getDocumentsFiltered({ page, limit, search, type, dataSet, redacted, mediaType });
       res.json({ ...result, data: result.data.map(omitInternal) });
     } catch (error) {
       res.status(500).json({ error: "Failed to fetch documents" });
@@ -128,6 +129,15 @@ export async function registerRoutes(
       res.json(filters);
     } catch (error) {
       res.status(500).json({ error: "Failed to fetch document filters" });
+    }
+  });
+
+  app.get("/api/sidebar-counts", async (_req, res) => {
+    try {
+      const counts = await storage.getSidebarCounts();
+      res.json(counts);
+    } catch (error) {
+      res.status(500).json({ error: "Failed to fetch sidebar counts" });
     }
   });
 


### PR DESCRIPTION
## Summary
- Restructure sidebar with grouped sections (Overview, Documents, Media, Investigation, Tools)
- Each section displays live counts fetched from `/api/sidebar-counts` 
- Document types now have individual sidebar items with counts
- Add mediaType filter to documents page with new dropdown
- Dynamic page titles update based on active filter (e.g., "Court Filings", "Photos")

## Implementation
- `scripts/pipeline/backfill-document-types.ts` normalizes 288 AI types into 12 canonical types
- `getSidebarCounts()` method efficiently aggregates counts in single-pass queries
- Sidebar nav items with query params now correctly detect active state
- Documents page supports filtering by both document type and media type

## Test Plan
- Run backfill script to populate canonical document types from AI data
- Run media-classifier to populate mediaType column
- Verify sidebar shows grouped sections with live counts
- Test each sidebar link pre-filters documents appropriately
- Verify page title changes when filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)