### PR TITLE
Fix PDF thumbnails, video grid cards, and video seeking

### DIFF
--- a/client/src/components/pdf-viewer.tsx
+++ b/client/src/components/pdf-viewer.tsx
@@ -22,7 +22,7 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
 
 interface PdfViewerProps {
   documentId: number;
-  sourceUrl: string;
+  sourceUrl?: string;
 }
 
 type ViewerState = "loading" | "ready" | "error";
@@ -90,7 +90,7 @@ export default function PdfViewer({ documentId, sourceUrl }: PdfViewerProps) {
       setViewerState("loading");
 
       // Try proxy endpoint first (avoids CORS), then direct URL
-      const urls = [`/api/documents/${documentId}/pdf`, sourceUrl];
+      const urls = [`/api/documents/${documentId}/pdf`, sourceUrl].filter(Boolean) as string[];
 
       for (const url of urls) {
         if (cancelled) return;
@@ -186,11 +186,13 @@ export default function PdfViewer({ documentId, sourceUrl }: PdfViewerProps) {
         <CardContent className="flex flex-col items-center gap-4 py-8">
           <AlertCircle className="w-8 h-8 text-muted-foreground/50" />
           <p className="text-sm text-muted-foreground text-center max-w-md">{errorMessage}</p>
-          <a href={sourceUrl} target="_blank" rel="noopener noreferrer">
-            <Button variant="outline" className="gap-2">
-              <ExternalLink className="w-4 h-4" /> Browse Source on DOJ Website
-            </Button>
-          </a>
+          {sourceUrl && (
+            <a href={sourceUrl} target="_blank" rel="noopener noreferrer">
+              <Button variant="outline" className="gap-2">
+                <ExternalLink className="w-4 h-4" /> Browse Source on DOJ Website
+              </Button>
+            </a>
+          )}
         </CardContent>
       </Card>
     );

--- a/client/src/pages/document-detail.tsx
+++ b/client/src/pages/document-detail.tsx
@@ -232,7 +232,7 @@ export default function DocumentDetailPage() {
         )}
       </div>
 
-      {doc.sourceUrl && (
+      {(doc.sourceUrl || doc.documentType) && (
         <>
           <Separator />
           <div className="flex flex-col gap-2">
@@ -378,5 +378,5 @@ function DocumentViewer({ doc }: { doc: DocumentDetail }) {
   }
 
   // Default: try PDF viewer, which will show a graceful fallback if it fails
-  return <PdfViewer documentId={doc.id} sourceUrl={doc.sourceUrl!} />;
+  return <PdfViewer documentId={doc.id} sourceUrl={doc.sourceUrl ?? undefined} />;
 }

--- a/client/src/pages/documents.tsx
+++ b/client/src/pages/documents.tsx
@@ -504,12 +504,21 @@ function PdfThumbnail({ docId }: { docId: number }) {
   return <canvas ref={canvasRef} width={400} className="w-full h-full object-cover" />;
 }
 
+function isPdfDocument(doc: Document): boolean {
+  if (doc.mediaType?.toLowerCase() === "pdf") return true;
+  if (doc.mimeType?.toLowerCase()?.includes("pdf")) return true;
+  if (doc.title?.toLowerCase().endsWith(".pdf")) return true;
+  const nonPdfTypes = new Set(["photograph", "video"]);
+  const docType = doc.documentType?.toLowerCase() || "";
+  return docType !== "" && !nonPdfTypes.has(docType);
+}
+
 function DocumentThumbnail({ doc }: { doc: Document }) {
   const mediaType = doc.mediaType?.toLowerCase() || "";
   const docType = doc.documentType?.toLowerCase() || "";
   const isPhoto = mediaType === "photo" || mediaType === "image" || docType === "photograph";
   const isVideo = mediaType === "video" || docType === "video";
-  const isPdf = doc.title?.toLowerCase().endsWith(".pdf");
+  const isPdf = isPdfDocument(doc);
   const Icon = typeIcons[doc.documentType] || FileText;
 
   if (isPhoto) {
@@ -528,9 +537,14 @@ function DocumentThumbnail({ doc }: { doc: Document }) {
 
   if (isVideo) {
     return (
-      <div className="flex flex-col items-center gap-1.5">
-        <Video className="w-8 h-8 text-muted-foreground/40" />
-        <span className="text-[10px] text-muted-foreground">Video</span>
+      <div className="absolute inset-0 bg-gradient-to-b from-zinc-800 to-zinc-900 flex items-center justify-center">
+        <div className="w-14 h-14 rounded-full bg-white/20 flex items-center justify-center">
+          <div className="w-0 h-0 border-t-[10px] border-t-transparent border-b-[10px] border-b-transparent border-l-[16px] border-l-white/80 ml-1" />
+        </div>
+        <div className="absolute top-2 left-2 flex items-center gap-1 bg-black/40 rounded px-1.5 py-0.5">
+          <Video className="w-3 h-3 text-white/70" />
+          <span className="text-[10px] text-white/70">Video</span>
+        </div>
       </div>
     );
   }

--- a/server/r2.ts
+++ b/server/r2.ts
@@ -77,18 +77,20 @@ export async function getPresignedUrl(
   );
 }
 
-export async function getR2Stream(key: string): Promise<{
+export async function getR2Stream(key: string, range?: string): Promise<{
   body: Readable;
   contentType?: string;
   contentLength?: number;
+  contentRange?: string;
 }> {
-  const resp = await getClient().send(
-    new GetObjectCommand({ Bucket: getBucket(), Key: key }),
-  );
+  const params: { Bucket: string; Key: string; Range?: string } = { Bucket: getBucket(), Key: key };
+  if (range) params.Range = range;
+  const resp = await getClient().send(new GetObjectCommand(params));
   return {
     body: resp.Body as unknown as Readable,
     contentType: resp.ContentType,
     contentLength: resp.ContentLength,
+    contentRange: resp.ContentRange,
   };
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -366,11 +366,20 @@ export async function registerRoutes(
       // Try R2 first
       if (doc.r2Key && isR2Configured()) {
         try {
-          const r2Resp = await getR2Stream(doc.r2Key);
+          const r2Resp = await getR2Stream(doc.r2Key, req.headers.range);
           res.setHeader("Content-Type", r2Resp.contentType || "video/mp4");
-          if (r2Resp.contentLength) res.setHeader("Content-Length", String(r2Resp.contentLength));
-          res.setHeader("Cache-Control", "private, max-age=3600");
-          r2Resp.body.pipe(res);
+          res.setHeader("Accept-Ranges", "bytes");
+          if (r2Resp.contentRange) {
+            res.setHeader("Content-Range", r2Resp.contentRange);
+            if (r2Resp.contentLength) res.setHeader("Content-Length", String(r2Resp.contentLength));
+            res.setHeader("Cache-Control", "private, max-age=3600");
+            res.status(206);
+            r2Resp.body.pipe(res);
+          } else {
+            if (r2Resp.contentLength) res.setHeader("Content-Length", String(r2Resp.contentLength));
+            res.setHeader("Cache-Control", "private, max-age=3600");
+            r2Resp.body.pipe(res);
+          }
           return;
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);
@@ -389,13 +398,36 @@ export async function registerRoutes(
             ".mov": "video/quicktime", ".wmv": "video/x-ms-wmv",
             ".webm": "video/webm",
           };
+          const stat = fsSync.statSync(absPath);
+          const fileSize = stat.size;
           res.setHeader("Content-Type", mimeMap[ext] || "video/mp4");
+          res.setHeader("Accept-Ranges", "bytes");
           res.setHeader("Cache-Control", "private, max-age=3600");
-          const stream = fsSync.createReadStream(absPath);
-          stream.on("error", () => {
-            if (!res.headersSent) res.status(500).json({ error: "File read error" });
-          });
-          stream.pipe(res);
+
+          if (req.headers.range) {
+            const parts = req.headers.range.replace(/bytes=/, "").split("-");
+            const start = parseInt(parts[0], 10);
+            const end = parts[1] ? parseInt(parts[1], 10) : fileSize - 1;
+            if (start >= fileSize || end >= fileSize || start > end) {
+              res.setHeader("Content-Range", `bytes */${fileSize}`);
+              return res.status(416).end();
+            }
+            res.setHeader("Content-Range", `bytes ${start}-${end}/${fileSize}`);
+            res.setHeader("Content-Length", String(end - start + 1));
+            res.status(206);
+            const stream = fsSync.createReadStream(absPath, { start, end });
+            stream.on("error", () => {
+              if (!res.headersSent) res.status(500).json({ error: "File read error" });
+            });
+            stream.pipe(res);
+          } else {
+            res.setHeader("Content-Length", String(fileSize));
+            const stream = fsSync.createReadStream(absPath);
+            stream.on("error", () => {
+              if (!res.headersSent) res.status(500).json({ error: "File read error" });
+            });
+            stream.pipe(res);
+          }
           return;
         }
       }
@@ -405,16 +437,22 @@ export async function registerRoutes(
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 120_000);
         try {
-          const response = await fetch(doc.sourceUrl, { signal: controller.signal });
+          const fetchHeaders: Record<string, string> = {};
+          if (req.headers.range) fetchHeaders["Range"] = req.headers.range;
+          const response = await fetch(doc.sourceUrl, { signal: controller.signal, headers: fetchHeaders });
           clearTimeout(timeout);
-          if (!response.ok) {
+          if (!response.ok && response.status !== 206) {
             return res.status(502).json({ error: "Failed to fetch video from source" });
           }
           const contentType = response.headers.get("content-type") || "video/mp4";
           const contentLength = response.headers.get("content-length");
+          const contentRange = response.headers.get("content-range");
           res.setHeader("Content-Type", contentType);
+          res.setHeader("Accept-Ranges", "bytes");
           if (contentLength) res.setHeader("Content-Length", contentLength);
+          if (contentRange) res.setHeader("Content-Range", contentRange);
           res.setHeader("Cache-Control", "public, max-age=86400");
+          if (response.status === 206) res.status(206);
           if (response.body) {
             Readable.fromWeb(response.body as any).pipe(res);
           } else {


### PR DESCRIPTION
## Summary
- Fixed PDF thumbnail detection to use `documentType` as fallback instead of just checking file extensions
- Redesigned video thumbnails with dark gradient card and centered play button for better visual hierarchy
- Show document viewer for local files even without an external `sourceUrl`
- Added HTTP range request support to video endpoint for seeking/scrubbing on all storage backends

## Changes
- `documents.tsx`: Added `isPdfDocument()` helper that checks `mediaType`, `mimeType`, and `documentType` fields
- `documents.tsx`: Replaced video icon with dark gradient card + semi-transparent play circle + badge
- `document-detail.tsx`: Removed `sourceUrl` requirement for showing document viewer
- `pdf-viewer.tsx`: Made `sourceUrl` optional, filter undefined from URL list
- `routes.ts`: Added HTTP 206 partial content support for local files, R2, and remote proxy paths
- `r2.ts`: Added optional `range` parameter to `getR2Stream()` with `contentRange` in response

## Verification
✅ Grid view shows PDF thumbnails instead of placeholder icons
✅ Video cards display dark background with centered play button
✅ Video seeking works by requesting byte ranges
✅ Docs with local files show viewer even without sourceUrl