### PR TITLE
Add redirect middleware for fly.dev domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A public record explorer for the Jeffrey Epstein case files released by the U.S. Department of Justice. Browse, search, and analyze documents across 12 data sets including court filings, depositions, FBI reports, flight logs, financial records, and more.
 
-Live at [epstein-file-explorer.replit.app](https://epstein-file-explorer.replit.app)
+Live at [epstein-file-explorer.com](https://epstein-file-explorer.com)
 
 ## Features
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -55,6 +55,14 @@ export async function registerRoutes(
   app: Express
 ): Promise<Server> {
 
+  // Redirect legacy fly.dev hostname to custom domain
+  app.use((req, res, next) => {
+    if (req.hostname === 'epstein-file-explorer.fly.dev') {
+      return res.redirect(301, `https://epstein-file-explorer.com${req.originalUrl}`);
+    }
+    next();
+  });
+
   app.get("/api/stats", async (_req, res) => {
     try {
       const stats = await storage.getStats();


### PR DESCRIPTION
Redirects legacy fly.dev hostname to the custom domain with a 301 permanent redirect while preserving the original URL path. Updates README to reflect the new primary domain.

🧠 Generated with Claude Code