### PR TITLE
Add social media links to sidebar footer

### DIFF
--- a/client/src/components/app-sidebar.tsx
+++ b/client/src/components/app-sidebar.tsx
@@ -23,6 +23,9 @@ import {
   Brain,
   ExternalLink,
   Heart,
+  Github,
+  Twitter,
+  Youtube,
   Shield,
   Gavel,
   Mail,
@@ -198,6 +201,36 @@ export function AppSidebar() {
           >
             <Heart className="w-3 h-3 text-rose-500" />
             <span>Sponsor on GitHub</span>
+          </a>
+          <a
+            href="https://x.com/OverviewEffect6"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 hover-elevate rounded-md p-1.5"
+            data-testid="link-twitter"
+          >
+            <Twitter className="w-3 h-3" />
+            <span>Follow on X</span>
+          </a>
+          <a
+            href="https://www.youtube.com/@vibecodingforgood"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 hover-elevate rounded-md p-1.5"
+            data-testid="link-youtube"
+          >
+            <Youtube className="w-3 h-3" />
+            <span>YouTube</span>
+          </a>
+          <a
+            href="https://github.com/Donnadieu"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 hover-elevate rounded-md p-1.5"
+            data-testid="link-github"
+          >
+            <Github className="w-3 h-3" />
+            <span>GitHub</span>
           </a>
           <a
             href="https://www.justice.gov/epstein"


### PR DESCRIPTION
## Summary
Added social media links to the sidebar footer, allowing users to easily follow the project on X, YouTube, and GitHub.

- X (Twitter): https://x.com/OverviewEffect6
- YouTube: https://www.youtube.com/@vibecodingforgood  
- GitHub: https://github.com/Donnadieu

Links are placed between support links and source links with consistent styling and hover effects.