### PR TITLE
Move donate and social links to top nav

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { NavActions } from "@/components/nav-actions";
 import { AppBreadcrumbs } from "@/components/breadcrumbs";
 import { useKeyboardShortcuts, shortcutsList } from "@/hooks/use-keyboard-shortcuts";
 import {
@@ -68,7 +69,10 @@ function AppShell() {
               <SidebarTrigger data-testid="button-sidebar-toggle" />
               <AppBreadcrumbs />
             </div>
-            <ThemeToggle />
+            <div className="flex items-center">
+              <NavActions />
+              <ThemeToggle />
+            </div>
           </header>
           <main className="flex-1 overflow-auto">
             <Router />

--- a/client/src/components/app-sidebar.tsx
+++ b/client/src/components/app-sidebar.tsx
@@ -22,10 +22,6 @@ import {
   Network,
   Brain,
   ExternalLink,
-  Heart,
-  Github,
-  Twitter,
-  Youtube,
   Shield,
   Gavel,
   Mail,
@@ -182,56 +178,6 @@ export function AppSidebar() {
       </SidebarContent>
       <SidebarFooter className="p-4">
         <div className="flex flex-col gap-2 text-[10px] text-muted-foreground">
-          <a
-            href="https://ko-fi.com/vibecodingforgood"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 hover-elevate rounded-md p-1.5"
-            data-testid="link-kofi"
-          >
-            <Heart className="w-3 h-3 text-rose-500" />
-            <span>Support on Ko-fi</span>
-          </a>
-          <a
-            href="https://github.com/sponsors/Donnadieu"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 hover-elevate rounded-md p-1.5"
-            data-testid="link-github-sponsors"
-          >
-            <Heart className="w-3 h-3 text-rose-500" />
-            <span>Sponsor on GitHub</span>
-          </a>
-          <a
-            href="https://x.com/OverviewEffect6"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 hover-elevate rounded-md p-1.5"
-            data-testid="link-twitter"
-          >
-            <Twitter className="w-3 h-3" />
-            <span>Follow on X</span>
-          </a>
-          <a
-            href="https://www.youtube.com/@vibecodingforgood"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 hover-elevate rounded-md p-1.5"
-            data-testid="link-youtube"
-          >
-            <Youtube className="w-3 h-3" />
-            <span>YouTube</span>
-          </a>
-          <a
-            href="https://github.com/Donnadieu"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 hover-elevate rounded-md p-1.5"
-            data-testid="link-github"
-          >
-            <Github className="w-3 h-3" />
-            <span>GitHub</span>
-          </a>
           <a
             href="https://www.justice.gov/epstein"
             target="_blank"

--- a/client/src/components/nav-actions.tsx
+++ b/client/src/components/nav-actions.tsx
@@ -1,0 +1,70 @@
+import { Heart, Github, Twitter, Youtube } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+
+const links = [
+  {
+    href: "https://ko-fi.com/vibecodingforgood",
+    icon: Heart,
+    label: "Support on Ko-fi",
+    testId: "link-kofi",
+    iconClass: "text-rose-500",
+  },
+  {
+    href: "https://github.com/sponsors/Donnadieu",
+    icon: Heart,
+    label: "Sponsor on GitHub",
+    testId: "link-github-sponsors",
+    iconClass: "text-rose-500",
+  },
+  {
+    href: "https://x.com/OverviewEffect6",
+    icon: Twitter,
+    label: "Follow on X",
+    testId: "link-twitter",
+  },
+  {
+    href: "https://www.youtube.com/@vibecodingforgood",
+    icon: Youtube,
+    label: "YouTube",
+    testId: "link-youtube",
+  },
+  {
+    href: "https://github.com/Donnadieu",
+    icon: Github,
+    label: "GitHub",
+    testId: "link-github",
+  },
+] as const;
+
+export function NavActions() {
+  return (
+    <div className="flex items-center">
+      {links.map((link) => (
+        <Tooltip key={link.testId}>
+          <TooltipTrigger asChild>
+            <Button
+              size="icon"
+              variant="ghost"
+              asChild
+            >
+              <a
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-testid={link.testId}
+              >
+                <link.icon className={`h-4 w-4 ${link.iconClass ?? ""}`} />
+              </a>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{link.label}</TooltipContent>
+        </Tooltip>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Move Ko-fi, GitHub Sponsors, X, YouTube, and GitHub links from the sidebar footer to the top navigation bar as icon buttons with tooltips.

**Why?**
- Sidebar is hidden on mobile behind a hamburger menu
- These donation CTAs and social links need to be always visible
- Icon buttons in the nav bar are persistent and mobile-friendly

**Changes**
- New `NavActions` component with icon-only buttons and tooltip labels
- Links moved from `SidebarFooter` to header's right side, next to the theme toggle
- Sidebar footer now shows only attribution and source links

**Test IDs preserved** - All existing test IDs remain unchanged for compatibility

🤖 Generated with Claude