### PR TITLE
Fix database performance: add indexes, increase pool, optimize queries

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -12,8 +12,9 @@ if (!process.env.DATABASE_URL) {
 
 export const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
-  max: 10,
+  max: 20,
   idleTimeoutMillis: 30_000,
   connectionTimeoutMillis: 10_000,
+  statement_timeout: 30_000,
 });
 export const db = drizzle(pool, { schema });

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,6 +4,8 @@ import { registerRoutes } from "./routes";
 import { serveStatic } from "./static";
 import { createServer } from "http";
 import { storage } from "./storage";
+import { pool } from "./db";
+import { runMigrations } from "./migrate";
 
 const app = express();
 const httpServer = createServer(app);
@@ -142,6 +144,14 @@ app.use((req, res, next) => {
   } else {
     const { setupVite } = await import("./vite");
     await setupVite(httpServer, app);
+  }
+
+  try {
+    log("Running database migrations...");
+    await runMigrations(pool);
+    log("Database migrations complete");
+  } catch (err: any) {
+    log(`Database migration warning: ${err.message}`);
   }
 
   const port = parseInt(process.env.PORT || "5000", 10);

--- a/server/migrate.ts
+++ b/server/migrate.ts
@@ -1,0 +1,49 @@
+import type pg from "pg";
+
+const migrations: { name: string; sql: string }[] = [
+  {
+    name: "pg_trgm extension",
+    sql: "CREATE EXTENSION IF NOT EXISTS pg_trgm",
+  },
+  {
+    name: "idx_documents_r2_id (partial index for r2Filter)",
+    sql: `CREATE INDEX IF NOT EXISTS idx_documents_r2_id
+           ON documents (id)
+           WHERE r2_key IS NOT NULL AND (file_size_bytes IS NULL OR file_size_bytes != 0)`,
+  },
+  {
+    name: "idx_documents_title_trgm",
+    sql: `CREATE INDEX IF NOT EXISTS idx_documents_title_trgm
+           ON documents USING gin (title gin_trgm_ops)`,
+  },
+  {
+    name: "idx_documents_description_trgm",
+    sql: `CREATE INDEX IF NOT EXISTS idx_documents_description_trgm
+           ON documents USING gin (description gin_trgm_ops)`,
+  },
+  {
+    name: "idx_documents_key_excerpt_trgm",
+    sql: `CREATE INDEX IF NOT EXISTS idx_documents_key_excerpt_trgm
+           ON documents USING gin (key_excerpt gin_trgm_ops)`,
+  },
+  {
+    name: "idx_persons_name_trgm",
+    sql: `CREATE INDEX IF NOT EXISTS idx_persons_name_trgm
+           ON persons USING gin (name gin_trgm_ops)`,
+  },
+  {
+    name: "idx_timeline_events_title_trgm",
+    sql: `CREATE INDEX IF NOT EXISTS idx_timeline_events_title_trgm
+           ON timeline_events USING gin (title gin_trgm_ops)`,
+  },
+];
+
+export async function runMigrations(pool: pg.Pool): Promise<void> {
+  for (const { name, sql } of migrations) {
+    try {
+      await pool.query(sql);
+    } catch (err: any) {
+      console.warn(`Migration skipped (${name}): ${err.message}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Creates pg_trgm extension + 6 GIN trigram indexes (run at startup via idempotent migration). Increases connection pool from 10→20, adds 30s statement timeout to prevent starvation. Optimizes adjacent document lookup from 2 queries to 1. Trims person search to name+occupation (removes low-value description/role fields).

## Changes

- **server/migrate.ts** (new): Idempotent SQL migration with extension + 6 trigram indexes
- **server/index.ts**: Hook migration into startup before listen()
- **server/db.ts**: Pool max 10→20, add statement_timeout 30_000
- **server/storage.ts**: Merge adjacent document queries, trim person search columns

## Test plan

- Start app locally, verify logs show migration complete
- Test search endpoints respond in <1s
- Verify trigram indexes exist in database

🤖 Generated with [Claude Code](https://claude.com/claude-code)