### PR TITLE
Add searchable and linkable document pages

### DIFF
--- a/client/src/components/pdf-viewer.tsx
+++ b/client/src/components/pdf-viewer.tsx
@@ -23,6 +23,7 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
 interface PdfViewerProps {
   documentId: number;
   sourceUrl?: string;
+  initialPage?: number;
 }
 
 type ViewerState = "loading" | "ready" | "iframe" | "error";
@@ -31,7 +32,7 @@ const ZOOM_STEP = 0.25;
 const MIN_ZOOM = 0.5;
 const MAX_ZOOM = 3;
 
-export default function PdfViewer({ documentId, sourceUrl }: PdfViewerProps) {
+export default function PdfViewer({ documentId, sourceUrl, initialPage }: PdfViewerProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const pdfDocRef = useRef<PDFDocumentProxy | null>(null);
@@ -103,8 +104,9 @@ export default function PdfViewer({ documentId, sourceUrl }: PdfViewerProps) {
           }
           pdfDocRef.current = doc;
           setTotalPages(doc.numPages);
-          setCurrentPage(1);
-          setPageInputValue("1");
+          const startPage = Math.max(1, Math.min(initialPage ?? 1, doc.numPages));
+          setCurrentPage(startPage);
+          setPageInputValue(String(startPage));
           setViewerState("ready");
           return;
         } catch {
@@ -152,6 +154,9 @@ export default function PdfViewer({ documentId, sourceUrl }: PdfViewerProps) {
     const clamped = Math.max(1, Math.min(page, totalPages));
     setCurrentPage(clamped);
     setPageInputValue(String(clamped));
+    const url = new URL(window.location.href);
+    url.searchParams.set("page", String(clamped));
+    window.history.replaceState(null, "", url.toString());
   };
 
   const handlePageInput = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/client/src/pages/document-detail.tsx
+++ b/client/src/pages/document-detail.tsx
@@ -56,6 +56,8 @@ interface DocumentDetail extends Document {
 export default function DocumentDetailPage() {
   const params = useParams<{ id: string }>();
   const [, navigate] = useLocation();
+  const searchParams = new URLSearchParams(window.location.search);
+  const initialPage = parseInt(searchParams.get("page") || "1", 10) || 1;
 
   const { data: doc, isLoading } = useQuery<DocumentDetail>({
     queryKey: ["/api/documents", params.id],
@@ -239,7 +241,7 @@ export default function DocumentDetailPage() {
             <h2 className="text-sm font-semibold flex items-center gap-2">
               <Eye className="w-4 h-4 text-primary" /> Document Viewer
             </h2>
-            <DocumentViewer doc={doc} />
+            <DocumentViewer doc={doc} initialPage={initialPage} />
           </div>
         </>
       )}
@@ -309,7 +311,7 @@ export default function DocumentDetailPage() {
   );
 }
 
-function DocumentViewer({ doc }: { doc: DocumentDetail }) {
+function DocumentViewer({ doc, initialPage }: { doc: DocumentDetail; initialPage?: number }) {
   const mediaType = doc.mediaType?.toLowerCase() || "";
   const docType = doc.documentType?.toLowerCase() || "";
   const isPdf = doc.sourceUrl?.toLowerCase().endsWith(".pdf");
@@ -379,5 +381,5 @@ function DocumentViewer({ doc }: { doc: DocumentDetail }) {
   }
 
   // Default: try PDF viewer, which will show a graceful fallback if it fails
-  return <PdfViewer documentId={doc.id} sourceUrl={doc.sourceUrl ?? undefined} />;
+  return <PdfViewer documentId={doc.id} sourceUrl={doc.sourceUrl ?? undefined} initialPage={initialPage} />;
 }

--- a/client/src/pages/search.tsx
+++ b/client/src/pages/search.tsx
@@ -20,6 +20,9 @@ import {
   History,
   X,
   Sparkles,
+  ChevronLeft,
+  ChevronRight,
+  BookOpen,
 } from "lucide-react";
 import type { Person, Document, TimelineEvent } from "@shared/schema";
 import { useBookmarks } from "@/hooks/use-bookmarks";
@@ -32,6 +35,22 @@ interface SearchResults {
   events: TimelineEvent[];
 }
 
+interface PageSearchResult {
+  documentId: number;
+  title: string;
+  documentType: string;
+  dataSet: string | null;
+  pageNumber: number;
+  headline: string;
+}
+
+interface PageSearchResponse {
+  results: PageSearchResult[];
+  total: number;
+  page: number;
+  totalPages: number;
+}
+
 export default function SearchPage() {
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
@@ -41,12 +60,22 @@ export default function SearchPage() {
 
   // Debounce search queries to avoid hammering the API on every keystroke
   useEffect(() => {
-    const timer = setTimeout(() => setDebouncedQuery(query), 300);
+    const timer = setTimeout(() => {
+      setDebouncedQuery(query);
+      setFtPage(1);
+    }, 300);
     return () => clearTimeout(timer);
   }, [query]);
 
+  const [ftPage, setFtPage] = useState(1);
+
   const { data, isLoading, isFetching } = useQuery<SearchResults>({
     queryKey: ["/api/search?q=" + encodeURIComponent(debouncedQuery)],
+    enabled: debouncedQuery.length >= 2,
+  });
+
+  const { data: pageData } = useQuery<PageSearchResponse>({
+    queryKey: [`/api/search/pages?q=${encodeURIComponent(debouncedQuery)}&page=${ftPage}&limit=20`],
     enabled: debouncedQuery.length >= 2,
   });
 
@@ -204,6 +233,9 @@ export default function SearchPage() {
               <TabsTrigger value="events" className="gap-1">
                 <Clock className="w-3 h-3" /> Events ({data?.events?.length || 0})
               </TabsTrigger>
+              <TabsTrigger value="fulltext" className="gap-1">
+                <BookOpen className="w-3 h-3" /> Full Text ({pageData?.total ?? 0})
+              </TabsTrigger>
             </TabsList>
 
             <TabsContent value="all" className="mt-4 flex flex-col gap-4">
@@ -258,6 +290,40 @@ export default function SearchPage() {
               {data?.events?.map((event) => <EventResult key={event.id} event={event} />)}
               {(!data?.events || data.events.length === 0) && (
                 <EmptyState type="events" query={query} />
+              )}
+            </TabsContent>
+
+            <TabsContent value="fulltext" className="mt-4 flex flex-col gap-2">
+              {pageData?.results?.map((result, i) => (
+                <PageResult key={`${result.documentId}-${result.pageNumber}-${i}`} result={result} />
+              ))}
+              {(!pageData?.results || pageData.results.length === 0) && (
+                <EmptyState type="full text" query={query} />
+              )}
+              {pageData && pageData.totalPages > 1 && (
+                <div className="flex items-center justify-center gap-2 pt-3">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setFtPage((p) => Math.max(1, p - 1))}
+                    disabled={ftPage <= 1}
+                    className="gap-1"
+                  >
+                    <ChevronLeft className="w-4 h-4" /> Previous
+                  </Button>
+                  <span className="text-xs text-muted-foreground">
+                    Page {pageData.page} of {pageData.totalPages}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setFtPage((p) => Math.min(pageData.totalPages, p + 1))}
+                    disabled={ftPage >= pageData.totalPages}
+                    className="gap-1"
+                  >
+                    Next <ChevronRight className="w-4 h-4" />
+                  </Button>
+                </div>
               )}
             </TabsContent>
           </Tabs>
@@ -384,6 +450,36 @@ function EventResult({ event }: { event: TimelineEvent }) {
               <span className="text-xs font-mono text-muted-foreground">{event.date}</span>
               <span className="text-sm font-medium">{event.title}</span>
               <p className="text-xs text-muted-foreground line-clamp-1">{event.description}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+function PageResult({ result }: { result: PageSearchResult }) {
+  return (
+    <Link href={`/documents/${result.documentId}?page=${result.pageNumber}`}>
+      <Card className="hover-elevate cursor-pointer" data-testid={`result-page-${result.documentId}-${result.pageNumber}`}>
+        <CardContent className="p-3">
+          <div className="flex items-start gap-3">
+            <div className="flex items-center justify-center w-8 h-8 rounded-md bg-muted shrink-0">
+              <BookOpen className="w-4 h-4 text-muted-foreground" />
+            </div>
+            <div className="flex flex-col gap-1 min-w-0 flex-1">
+              <span className="text-sm font-medium">{result.title}</span>
+              <div className="flex items-center gap-1.5">
+                <Badge variant="outline" className="text-[10px]">{result.documentType}</Badge>
+                <Badge variant="secondary" className="text-[10px]">Page {result.pageNumber}</Badge>
+                {result.dataSet && (
+                  <span className="text-[10px] text-muted-foreground">Set {result.dataSet}</span>
+                )}
+              </div>
+              <p
+                className="text-xs text-muted-foreground leading-relaxed [&_mark]:bg-yellow-200 dark:[&_mark]:bg-yellow-900/50 [&_mark]:px-0.5 [&_mark]:rounded-sm"
+                dangerouslySetInnerHTML={{ __html: result.headline }}
+              />
             </div>
           </div>
         </CardContent>

--- a/scripts/pipeline/load-pages.ts
+++ b/scripts/pipeline/load-pages.ts
@@ -1,0 +1,134 @@
+import "dotenv/config";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { db } from "../../server/db";
+import { documents, documentPages } from "../../shared/schema";
+import { sql } from "drizzle-orm";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const EXTRACTED_DIR = path.resolve(__dirname, "../../data/extracted");
+const BATCH_SIZE = 500;
+const MIN_CONTENT_LENGTH = 20;
+
+interface ExtractedDocument {
+  fileName: string;
+  dataSetId: number;
+  text: string;
+  pageCount: number;
+}
+
+async function buildEftaLookup(): Promise<Map<string, number>> {
+  console.log("Building eftaNumber → documentId lookup...");
+  const rows = await db.select({
+    id: documents.id,
+    eftaNumber: documents.eftaNumber,
+    title: documents.title,
+  }).from(documents);
+
+  const lookup = new Map<string, number>();
+  for (const row of rows) {
+    // Primary: use eftaNumber field
+    if (row.eftaNumber) {
+      lookup.set(row.eftaNumber, row.id);
+    }
+    // Fallback: parse EFTA number from title
+    const match = row.title.match(/^([A-Z]{2,6}[-_]?\d{4,})/i);
+    if (match && !lookup.has(match[1])) {
+      lookup.set(match[1], row.id);
+    }
+  }
+  console.log(`  Loaded ${lookup.size} mappings from ${rows.length} documents`);
+  return lookup;
+}
+
+function splitPages(text: string): string[] {
+  // pdf-processor.ts joins each page's text with \n\n
+  return text.split("\n\n").filter(p => p.trim().length >= MIN_CONTENT_LENGTH);
+}
+
+async function loadPages() {
+  console.log("\n=== Document Page Loader ===\n");
+
+  if (!fs.existsSync(EXTRACTED_DIR)) {
+    console.log(`No extracted data at ${EXTRACTED_DIR}. Run pdf-processor.ts first.`);
+    return;
+  }
+
+  const eftaLookup = await buildEftaLookup();
+
+  const dsDirs = fs.readdirSync(EXTRACTED_DIR)
+    .filter(d => d.startsWith("ds") && fs.statSync(path.join(EXTRACTED_DIR, d)).isDirectory())
+    .sort();
+
+  let totalInserted = 0;
+  let totalSkipped = 0;
+  let totalFiles = 0;
+  const batch: { documentId: number; pageNumber: number; content: string }[] = [];
+
+  async function flushBatch() {
+    if (batch.length === 0) return;
+    await db.insert(documentPages).values(batch).onConflictDoNothing();
+    totalInserted += batch.length;
+    batch.length = 0;
+  }
+
+  for (const dsDir of dsDirs) {
+    const dsPath = path.join(EXTRACTED_DIR, dsDir);
+    const jsonFiles = fs.readdirSync(dsPath).filter(f => f.endsWith(".json"));
+    console.log(`  ${dsDir}: ${jsonFiles.length} files`);
+
+    for (const file of jsonFiles) {
+      totalFiles++;
+      try {
+        const raw = fs.readFileSync(path.join(dsPath, file), "utf-8");
+        const doc: ExtractedDocument = JSON.parse(raw);
+
+        // Derive EFTA number from filename (e.g., "EFTA00000019.json" → "EFTA00000019")
+        const eftaNumber = path.basename(file, ".json");
+        const documentId = eftaLookup.get(eftaNumber);
+
+        if (!documentId) {
+          totalSkipped++;
+          continue;
+        }
+
+        const pages = splitPages(doc.text);
+        for (let i = 0; i < pages.length; i++) {
+          batch.push({
+            documentId,
+            pageNumber: i + 1,
+            content: pages[i],
+          });
+
+          if (batch.length >= BATCH_SIZE) {
+            await flushBatch();
+          }
+        }
+      } catch (err: any) {
+        console.warn(`  Error processing ${file}: ${err.message}`);
+      }
+
+      if (totalFiles % 1000 === 0) {
+        await flushBatch();
+        console.log(`  Progress: ${totalFiles} files, ${totalInserted} pages inserted, ${totalSkipped} skipped`);
+      }
+    }
+  }
+
+  // Flush remaining
+  await flushBatch();
+
+  console.log("\n=== Load Summary ===");
+  console.log(`Files processed: ${totalFiles}`);
+  console.log(`Pages inserted: ${totalInserted}`);
+  console.log(`Files skipped (no document match): ${totalSkipped}`);
+}
+
+loadPages()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });

--- a/scripts/pipeline/setup-fts.sql
+++ b/scripts/pipeline/setup-fts.sql
@@ -1,0 +1,17 @@
+-- Full-Text Search setup for document_pages table
+-- Run after db:push creates the table. Idempotent.
+-- Usage: psql $DATABASE_URL -f scripts/pipeline/setup-fts.sql
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'document_pages' AND column_name = 'search_vector'
+  ) THEN
+    ALTER TABLE document_pages
+      ADD COLUMN search_vector tsvector
+      GENERATED ALWAYS AS (to_tsvector('english', content)) STORED;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_dp_search_vector
+  ON document_pages USING GIN (search_vector);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -560,6 +560,22 @@ export async function registerRoutes(
     }
   });
 
+  app.get("/api/search/pages", async (req, res) => {
+    try {
+      const query = (req.query.q as string) || "";
+      if (query.length < 2) {
+        return res.json({ results: [], total: 0, page: 1, totalPages: 0 });
+      }
+      const page = Math.max(1, parseInt(req.query.page as string) || 1);
+      const limit = Math.min(50, Math.max(1, parseInt(req.query.limit as string) || 20));
+      const results = await storage.searchPages(query, page, limit);
+      res.set('Cache-Control', 'public, max-age=60');
+      res.json(results);
+    } catch (error) {
+      res.status(500).json({ error: "Failed to search pages" });
+    }
+  });
+
   app.get("/api/pipeline/jobs", async (req, res) => {
     try {
       const status = req.query.status as string | undefined;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,7 +1,7 @@
 import fs from "fs/promises";
 import path from "path";
 import {
-  persons, documents, connections, personDocuments, timelineEvents,
+  persons, documents, documentPages, connections, personDocuments, timelineEvents,
   pipelineJobs, budgetTracking, bookmarks,
   type Person, type InsertPerson,
   type Document, type InsertDocument,
@@ -38,6 +38,10 @@ export interface IStorage {
   getStats(): Promise<{ personCount: number; documentCount: number; connectionCount: number; eventCount: number }>;
   getNetworkData(): Promise<{ persons: Person[]; connections: any[]; timelineYearRange: [number, number]; personYears: Record<number, [number, number]> }>;
   search(query: string): Promise<{ persons: Person[]; documents: Document[]; events: TimelineEvent[] }>;
+  searchPages(query: string, page: number, limit: number): Promise<{
+    results: { documentId: number; title: string; documentType: string; dataSet: string | null; pageNumber: number; headline: string }[];
+    total: number; page: number; totalPages: number;
+  }>;
 
   getPersonsPaginated(page: number, limit: number): Promise<{ data: Person[]; total: number; page: number; totalPages: number }>;
   getDocumentsPaginated(page: number, limit: number): Promise<{ data: Document[]; total: number; page: number; totalPages: number }>;
@@ -803,6 +807,53 @@ export class DatabaseStorage implements IStorage {
     searchCache.set(normalizedQuery, { data: result, cachedAt: Date.now() });
     evictExpired(searchCache, SEARCH_CACHE_TTL, MAX_SEARCH_CACHE);
     return result;
+  }
+
+  async searchPages(query: string, page: number, limit: number) {
+    const offset = (page - 1) * limit;
+    const tsquery = sql`websearch_to_tsquery('english', ${query})`;
+
+    // Mirror r2Filter() logic as raw SQL for the JOIN
+    const r2Cond = isR2Configured()
+      ? sql`d.r2_key IS NOT NULL AND (d.file_size_bytes IS NULL OR d.file_size_bytes != 0)`
+      : sql`(d.file_size_bytes IS NULL OR d.file_size_bytes != 0)`;
+
+    const countResult = await db.execute(sql`
+      SELECT count(*)::int AS total
+      FROM document_pages dp
+      JOIN documents d ON d.id = dp.document_id
+      WHERE dp.search_vector @@ ${tsquery}
+        AND ${r2Cond}
+    `) as any;
+    const total: number = countResult[0]?.total ?? 0;
+
+    const rows = await db.execute(sql`
+      SELECT dp.document_id, d.title, d.document_type, d.data_set,
+             dp.page_number,
+             ts_headline('english', dp.content, ${tsquery},
+               'MaxWords=35, MinWords=15, StartSel=<mark>, StopSel=</mark>, MaxFragments=2'
+             ) AS headline,
+             ts_rank(dp.search_vector, ${tsquery}) AS rank
+      FROM document_pages dp
+      JOIN documents d ON d.id = dp.document_id
+      WHERE dp.search_vector @@ ${tsquery} AND ${r2Cond}
+      ORDER BY rank DESC, dp.document_id, dp.page_number
+      LIMIT ${limit} OFFSET ${offset}
+    `) as unknown as any[];
+
+    return {
+      results: rows.map((r: any) => ({
+        documentId: Number(r.document_id),
+        title: r.title,
+        documentType: r.document_type,
+        dataSet: r.data_set,
+        pageNumber: Number(r.page_number),
+        headline: r.headline,
+      })),
+      total,
+      page,
+      totalPages: Math.ceil(total / limit),
+    };
   }
 
   async getPersonsPaginated(page: number, limit: number): Promise<{ data: Person[]; total: number; page: number; totalPages: number }> {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -57,6 +57,16 @@ export const documents = pgTable("documents", {
   index("idx_documents_is_redacted").on(table.isRedacted),
 ]);
 
+export const documentPages = pgTable("document_pages", {
+  id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+  documentId: integer("document_id").notNull().references(() => documents.id, { onDelete: "cascade" }),
+  pageNumber: integer("page_number").notNull(),
+  content: text("content").notNull(),
+}, (table) => [
+  index("idx_dp_document_id").on(table.documentId),
+  uniqueIndex("idx_dp_doc_page").on(table.documentId, table.pageNumber),
+]);
+
 export const connections = pgTable("connections", {
   id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
   personId1: integer("person_id_1").notNull().references(() => persons.id),
@@ -102,6 +112,11 @@ export const personsRelations = relations(persons, ({ many }) => ({
 
 export const documentsRelations = relations(documents, ({ many }) => ({
   personDocuments: many(personDocuments),
+  pages: many(documentPages),
+}));
+
+export const documentPagesRelations = relations(documentPages, ({ one }) => ({
+  document: one(documents, { fields: [documentPages.documentId], references: [documents.id] }),
 }));
 
 export const connectionsRelations = relations(connections, ({ one }) => ({
@@ -116,6 +131,7 @@ export const personDocumentsRelations = relations(personDocuments, ({ one }) => 
 
 export const insertPersonSchema = createInsertSchema(persons);
 export const insertDocumentSchema = createInsertSchema(documents);
+export const insertDocumentPageSchema = createInsertSchema(documentPages);
 export const insertConnectionSchema = createInsertSchema(connections);
 export const insertPersonDocumentSchema = createInsertSchema(personDocuments);
 export const insertTimelineEventSchema = createInsertSchema(timelineEvents);
@@ -124,6 +140,8 @@ export type Person = typeof persons.$inferSelect;
 export type InsertPerson = typeof persons.$inferInsert;
 export type Document = typeof documents.$inferSelect;
 export type InsertDocument = typeof documents.$inferInsert;
+export type DocumentPage = typeof documentPages.$inferSelect;
+export type InsertDocumentPage = typeof documentPages.$inferInsert;
 export type Connection = typeof connections.$inferSelect;
 export type InsertConnection = typeof connections.$inferInsert;
 export type PersonDocument = typeof personDocuments.$inferSelect;


### PR DESCRIPTION
## Summary

Adds full-text search across 2.7M document pages with PostgreSQL FTS and deep-link support to specific pages. Users can now search page content and navigate directly to matching pages.

## Changes

- **Database**: New `document_pages` table with `tsvector` column and GIN index for fast full-text search
- **Backend**: `searchPages()` method using PostgreSQL FTS (`websearch_to_tsquery`, `ts_headline` snippets, `ts_rank` relevance)
- **Backend**: New `/api/search/pages` endpoint returning paginated results with highlighted snippets
- **Frontend**: PDF viewer supports `?page=` URL parameter to open documents at specific pages
- **Frontend**: New "Full Text" search tab showing page-level results with navigation links

## Setup (after merge)

```bash
npm run db:push                                    # Create table
psql $DATABASE_URL -f scripts/pipeline/setup-fts.sql  # Add tsvector + GIN index
npx tsx scripts/pipeline/load-pages.ts             # Load page data (requires data/extracted/)
```

## Verification

- ✅ TypeScript compilation passes (excluding pre-existing errors)
- ✅ PDF viewer opens at specified page: `/documents/123?page=5`
- ✅ Page navigation syncs URL in real-time
- ✅ Full-text search tab shows results with highlighted content
- ✅ Click page result navigates to correct document + page