### PR TITLE
Link timeline events to people and documents

### DIFF
--- a/client/src/pages/document-detail.tsx
+++ b/client/src/pages/document-detail.tsx
@@ -49,8 +49,19 @@ function getDisplayTitle(doc: Document): string {
   return `${typeName}${setInfo}${dateInfo}`;
 }
 
+interface DocumentEvent {
+  id: number;
+  date: string;
+  title: string;
+  description: string;
+  category: string;
+  significance: number;
+  persons?: { id: number; name: string }[];
+}
+
 interface DocumentDetail extends Document {
   persons: (Person & { mentionType: string; context: string | null })[];
+  timelineEvents?: DocumentEvent[];
 }
 
 export default function DocumentDetailPage() {
@@ -306,6 +317,43 @@ export default function DocumentDetailPage() {
           </div>
         )}
       </div>
+
+      {/* Related Timeline Events */}
+      {doc.timelineEvents && doc.timelineEvents.length > 0 && (
+        <>
+          <Separator />
+          <div className="flex flex-col gap-3">
+            <h2 className="text-sm font-semibold flex items-center gap-2">
+              <Clock className="w-4 h-4 text-primary" /> Related Events ({doc.timelineEvents.length})
+            </h2>
+            <div className="flex flex-col gap-2">
+              {doc.timelineEvents.map((event) => (
+                <Card key={event.id} data-testid={`card-event-${event.id}`}>
+                  <CardContent className="p-3">
+                    <div className="flex items-start gap-3">
+                      <span className="text-[11px] font-mono text-muted-foreground shrink-0 pt-0.5">{event.date}</span>
+                      <div className="flex flex-col gap-1 min-w-0 flex-1">
+                        <span className="text-sm font-medium">{event.title}</span>
+                        <p className="text-xs text-muted-foreground">{event.description}</p>
+                        <div className="flex items-center gap-1.5 flex-wrap mt-0.5">
+                          <Badge variant="outline" className="text-[10px]">{event.category}</Badge>
+                          {event.persons?.map((p) => (
+                            <Link key={p.id} href={`/people/${p.id}`}>
+                              <Badge variant="secondary" className="text-[10px] cursor-pointer hover:bg-primary/10">
+                                {p.name}
+                              </Badge>
+                            </Link>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/client/src/pages/person-detail.tsx
+++ b/client/src/pages/person-detail.tsx
@@ -364,17 +364,17 @@ export default function PersonDetail() {
         {hasTimeline && (
           <TabsContent value="timeline" className="mt-4">
             <div className="flex flex-col gap-3">
-              {person.timelineEvents!.map((event) => (
+              {person.timelineEvents!.map((event: any) => (
                 <Card key={event.id} data-testid={`card-event-${event.id}`}>
                   <CardContent className="p-4">
                     <div className="flex items-start gap-3">
                       <div className="flex flex-col items-center gap-1 shrink-0 w-20">
                         <span className="text-xs font-mono text-muted-foreground">{event.date}</span>
                         <div className="flex items-center gap-0.5">
-                          {Array.from({ length: Math.min(event.significance, 5) }).map((_, i) => (
+                          {Array.from({ length: Math.min(event.significance, 5) }).map((_: unknown, i: number) => (
                             <div key={i} className="w-1.5 h-1.5 rounded-full bg-primary" />
                           ))}
-                          {Array.from({ length: Math.max(0, 5 - event.significance) }).map((_, i) => (
+                          {Array.from({ length: Math.max(0, 5 - event.significance) }).map((_: unknown, i: number) => (
                             <div key={i} className="w-1.5 h-1.5 rounded-full bg-muted" />
                           ))}
                         </div>
@@ -383,6 +383,34 @@ export default function PersonDetail() {
                         <span className="text-sm font-medium">{event.title}</span>
                         <p className="text-xs text-muted-foreground">{event.description}</p>
                         <Badge variant="outline" className="text-[10px] w-fit mt-1">{event.category}</Badge>
+
+                        {/* Linked people */}
+                        {event.persons?.length > 0 && (
+                          <div className="flex items-center gap-1 flex-wrap mt-1">
+                            <Users className="w-3 h-3 text-muted-foreground shrink-0" />
+                            {event.persons.map((p: { id: number; name: string }, i: number) => (
+                              <Link key={p.id} href={`/people/${p.id}`}>
+                                <span className="text-[11px] text-primary hover:underline cursor-pointer">
+                                  {p.name}{i < event.persons.length - 1 ? "," : ""}
+                                </span>
+                              </Link>
+                            ))}
+                          </div>
+                        )}
+
+                        {/* Linked documents */}
+                        {event.documents?.length > 0 && (
+                          <div className="flex items-center gap-1 flex-wrap mt-0.5">
+                            <FileText className="w-3 h-3 text-muted-foreground shrink-0" />
+                            {event.documents.map((d: { id: number; title: string }, i: number) => (
+                              <Link key={d.id} href={`/documents/${d.id}`}>
+                                <span className="text-[11px] text-primary hover:underline cursor-pointer">
+                                  {d.title.length > 40 ? d.title.slice(0, 40) + "…" : d.title}{i < event.documents.length - 1 ? "," : ""}
+                                </span>
+                              </Link>
+                            ))}
+                          </div>
+                        )}
                       </div>
                     </div>
                   </CardContent>

--- a/client/src/pages/timeline.tsx
+++ b/client/src/pages/timeline.tsx
@@ -15,6 +15,11 @@ import {
 import type { TimelineEvent } from "@shared/schema";
 import TimelineViz from "@/components/timeline-viz";
 
+interface EnrichedTimelineEvent extends TimelineEvent {
+  persons?: { id: number; name: string }[];
+  documents?: { id: number; title: string }[];
+}
+
 const DECADES = [
   { label: "All Time", start: 0, end: 2099 },
   { label: "1950s", start: 1950, end: 1959 },
@@ -31,7 +36,7 @@ export default function TimelinePage() {
   const [yearFrom, setYearFrom] = useState("1980");
   const [yearTo, setYearTo] = useState("");
 
-  const { data: events, isLoading } = useQuery<TimelineEvent[]>({
+  const { data: events, isLoading } = useQuery<EnrichedTimelineEvent[]>({
     queryKey: ["/api/timeline"],
     staleTime: 600_000,
   });


### PR DESCRIPTION
## Summary

Events are now enriched with person names and document titles throughout the application. When AI ingests documents, the source document is automatically linked to extracted events. The timeline page, person detail view, and new document detail section all display these rich links for navigation.

## Changes

- **db-loader.ts**: Populate `documentIds` during AI event ingestion by resolving the source document ID from the analysis filename
- **storage.ts**: Enrich all timeline APIs with person names and document titles via batch queries
- **timeline-viz.tsx**: Display clickable person and document links in event cards with navigation to detail pages
- **person-detail.tsx**: Show related documents and people in the person's timeline tab
- **document-detail.tsx**: Add "Related Events" section showing timeline events tied to the document
- **timeline.tsx**: Update query type to support enriched event data

## Test Plan

- Verify timeline page displays person and document links in event cards
- Verify clicking links navigates to person/document detail pages
- Verify person detail page shows linked documents and people in timeline tab
- Verify document detail page shows related events with person links

🤖 Generated with [Claude Code](https://claude.com/claude-code)