### PR TITLE
Display page count instead of document count on dashboard

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -136,6 +136,7 @@ export default function Dashboard() {
   const { data: stats, isLoading: statsLoading } = useQuery<{
     personCount: number;
     documentCount: number;
+    pageCount: number;
     connectionCount: number;
     eventCount: number;
   }>({
@@ -185,7 +186,7 @@ export default function Dashboard() {
         ) : (
           <>
             <StatCard icon={Users} label="People" value={stats?.personCount || 0} sublabel="Named individuals" href="/people" />
-            <StatCard icon={FileText} label="Documents" value={stats?.documentCount || 0} sublabel="Public records" href="/documents" />
+            <StatCard icon={FileText} label="Pages" value={stats?.pageCount || 0} sublabel="Across all documents" href="/documents" />
             <StatCard icon={Network} label="Connections" value={stats?.connectionCount || 0} sublabel="Mapped relationships" href="/network" />
             <StatCard icon={Clock} label="Events" value={stats?.eventCount || 0} sublabel="Timeline entries" href="/timeline" />
           </>


### PR DESCRIPTION
Show the total number of pages across all documents in the dashboard stats card rather than the number of documents. This provides a more meaningful metric of the archive's content volume.

## Changes

- Added `pageCount` field to stats API endpoint
- Updated dashboard to sum all document pages instead of counting documents
- Changed stat card label from "Documents" to "Pages"

🤖 Generated with Claude Code