### PR TITLE
Fix dedup pipeline data loss bugs

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -280,14 +280,18 @@ export function isSamePerson(a: Person, b: Person): boolean {
 
   // OCR collapse produces single token → fuzzy match against other name's parts
   // Catches "E stein" (→ "estein") matching "epstein" in "Jeffrey Epstein"
+  // Guard: skip when collapsed name came from initial+lastname (e.g. "G. Maxwell" → "gmaxwell")
+  // because editDistance("gmaxwell", "maxwell") = 1, which would chain-merge ALL Maxwells
   const collapsedPartsA = collapsedA.split(" ").filter(Boolean);
   const collapsedPartsB = collapsedB.split(" ").filter(Boolean);
-  if (collapsedPartsA.length === 1 && collapsedPartsA[0].length >= 5) {
+  const isInitialA = partsA.length === 2 && partsA[0].length === 1 && partsA[1].length >= 4;
+  const isInitialB = partsB.length === 2 && partsB[0].length === 1 && partsB[1].length >= 4;
+  if (collapsedPartsA.length === 1 && collapsedPartsA[0].length >= 5 && !isInitialA) {
     for (const part of partsB) {
       if (part.length >= 5 && editDistance(collapsedPartsA[0], part) <= 1) return true;
     }
   }
-  if (collapsedPartsB.length === 1 && collapsedPartsB[0].length >= 5) {
+  if (collapsedPartsB.length === 1 && collapsedPartsB[0].length >= 5 && !isInitialB) {
     for (const part of partsA) {
       if (part.length >= 5 && editDistance(collapsedPartsB[0], part) <= 1) return true;
     }


### PR DESCRIPTION
## Summary

Fixes critical data loss in the deduplication pipeline where key figures (Ghislaine Maxwell with 922 mentions, Jeffrey Epstein with 1,449 mentions) were being deleted due to over-aggressive fuzzy matching.

**Root causes:**
- "G. Maxwell" OCR-collapses to "gmaxwell", which has edit distance 1 from "maxwell", causing all Maxwells to chain-merge via union-find
- Same issue for "J. Epstein" → "jepstein" → matches "epstein"

**Solutions:**
1. Block OCR-collapse fuzzy path for initial+lastname patterns (2 parts, first is 1 char, second ≥4 chars)
2. Load Wikipedia key figures into protected set, never delete them
3. Select canonical by name quality (protected > meaningful parts > name length > counts) instead of counts (which are 0 at dedup time)
4. Improve Pass 3 filter to use `normalizeName()` and skip protected persons
5. Add more junk patterns (possessives, "the/former" prefixes, title+of patterns)
6. Add progress logging for long-running operations

🧪 Generated with [Claude Code](https://claude.com/claude-code)