### PR TITLE
Fix DeepSeek API key loading in classify-from-pages

### DIFF
--- a/scripts/pipeline/classify-from-pages.ts
+++ b/scripts/pipeline/classify-from-pages.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import OpenAI from "openai";
 import { db } from "../../server/db";
 import { documents, documentPages, budgetTracking } from "../../shared/schema";


### PR DESCRIPTION
## Summary

Fixed missing `dotenv/config` import in the page classification pipeline script. The script was already configured to use DeepSeek, but the environment variable wasn't being loaded from `.env`, causing API key errors.

This brings the script in line with all other pipeline scripts that load environment variables through the dotenv import.

## Changes

- Added `import "dotenv/config"` to `scripts/pipeline/classify-from-pages.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)