### PR TITLE
Allow scripts/pipeline in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,6 @@ data/extracted
 data/raw
 data/.chrome-profile
 data/torrent-staging
-scripts/pipeline
 *.tar.gz
 .DS_Store
 .env


### PR DESCRIPTION
## Summary

Remove `scripts/pipeline` from `.dockerignore` to allow esbuild to resolve the pipeline entry point during Docker build. This enables bundling the pipeline into `dist/pipeline.cjs` for production deployment.

## Details

The pipeline bundling added in PR #69 requires access to `scripts/pipeline/run-pipeline.ts` during the build stage. Excluding it from the Docker build context caused esbuild to fail with "Could not resolve 'scripts/pipeline/run-pipeline.ts'" during Fly.io deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)