### PR TITLE
Fix document & page classification system

### DIFF
--- a/client/src/pages/document-detail.tsx
+++ b/client/src/pages/document-detail.tsx
@@ -259,6 +259,25 @@ export default function DocumentDetailPage() {
           )}
         </div>
 
+        {doc.pageTypes && doc.pageTypes.length > 0 && (() => {
+          const typeCounts = new Map<string, number>();
+          for (const pt of doc.pageTypes) {
+            if (pt.pageType) typeCounts.set(pt.pageType, (typeCounts.get(pt.pageType) || 0) + 1);
+          }
+          if (typeCounts.size <= 1) return null;
+          const sorted = [...typeCounts.entries()].sort((a, b) => b[1] - a[1]);
+          return (
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-xs text-muted-foreground font-medium">Contains:</span>
+              {sorted.map(([type, count]) => (
+                <Badge key={type} variant="secondary" className="text-[10px]">
+                  {count} {type}{count > 1 ? "s" : ""}
+                </Badge>
+              ))}
+            </div>
+          );
+        })()}
+
         {doc.sourceUrl && (
           <a href={doc.sourceUrl} target="_blank" rel="noopener noreferrer">
             <Button variant="outline" className="gap-2 w-fit" data-testid="button-view-source">

--- a/client/src/pages/search.tsx
+++ b/client/src/pages/search.tsx
@@ -43,6 +43,7 @@ interface PageSearchResult {
   dataSet: string | null;
   pageNumber: number;
   headline: string;
+  pageType: string | null;
 }
 
 interface PageSearchResponse {
@@ -98,7 +99,7 @@ export default function SearchPage() {
       title: string;
       documentType: string;
       dataSet: string | null;
-      pages: { pageNumber: number; headline: string }[];
+      pages: { pageNumber: number; headline: string; pageType: string | null }[];
     }>();
     for (const result of pageData.results) {
       let group = groups.get(result.documentId);
@@ -112,7 +113,7 @@ export default function SearchPage() {
         };
         groups.set(result.documentId, group);
       }
-      group.pages.push({ pageNumber: result.pageNumber, headline: result.headline });
+      group.pages.push({ pageNumber: result.pageNumber, headline: result.headline, pageType: result.pageType });
     }
     return Array.from(groups.values());
   }, [pageData?.results]);
@@ -348,6 +349,11 @@ export default function SearchPage() {
                                     <Badge variant="secondary" className="text-[10px] shrink-0 mt-0.5">
                                       Page {page.pageNumber}
                                     </Badge>
+                                    {page.pageType && page.pageType !== group.documentType && (
+                                      <Badge variant="outline" className="text-[10px] shrink-0 mt-0.5">
+                                        {page.pageType}
+                                      </Badge>
+                                    )}
                                     <p
                                       className="text-xs text-muted-foreground leading-relaxed [&_mark]:bg-yellow-200 dark:[&_mark]:bg-yellow-900/50 [&_mark]:px-0.5 [&_mark]:rounded-sm"
                                       dangerouslySetInnerHTML={{ __html: page.headline }}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -39,7 +39,7 @@ export interface IStorage {
   getNetworkData(): Promise<{ persons: Person[]; connections: any[]; timelineYearRange: [number, number]; personYears: Record<number, [number, number]> }>;
   search(query: string): Promise<{ persons: Person[]; documents: Document[]; events: TimelineEvent[] }>;
   searchPages(query: string, page: number, limit: number, useOrMode?: boolean): Promise<{
-    results: { documentId: number; title: string; documentType: string; dataSet: string | null; pageNumber: number; headline: string }[];
+    results: { documentId: number; title: string; documentType: string; dataSet: string | null; pageNumber: number; headline: string; pageType: string | null }[];
     total: number; page: number; totalPages: number;
   }>;
 
@@ -1005,7 +1005,7 @@ export class DatabaseStorage implements IStorage {
 
     const rawResult: any = await db.execute(sql`
       SELECT dp.document_id, d.title, d.document_type, d.data_set,
-             dp.page_number,
+             dp.page_number, dp.page_type,
              ts_headline('english', dp.content, ${tsquery},
                'MaxWords=35, MinWords=15, StartSel=<mark>, StopSel=</mark>, MaxFragments=2'
              ) AS headline,
@@ -1026,6 +1026,7 @@ export class DatabaseStorage implements IStorage {
         dataSet: r.data_set,
         pageNumber: Number(r.page_number),
         headline: r.headline,
+        pageType: r.page_type ?? null,
       })),
       total,
       page,


### PR DESCRIPTION
## Summary

Implements comprehensive fixes to the document classification system to ensure AI-analyzed document types are properly written to the database and page-level classifications are surfaced in the UI.

## What Changed

**Part 1:** `loadAIResults()` now writes `documentType` from AI JSON analysis to the database (previously ignored)

**Part 2:** Expanded `CANONICAL_TYPE_MAP` with improved patterns for:
- Correspondence: added calendar/appointment/schedule keywords
- Police reports: added prison/correctional/jail/inmate keywords  
- Government records: made explicit pattern instead of fallback

Changed fallback from "government record" to "other", which resolves to parent document type for context.

**Part 3a:** Added `page_type` to search results API and rendered as badges next to page numbers in UI (when different from document type)

**Part 3b:** Added page type summary in document detail metadata showing type distribution (e.g., "Contains: 5 court filings, 3 emails, 2 financial records")

## Files Modified

- `scripts/pipeline/db-loader.ts` - Add normalizeType() and update documentType during AI load
- `scripts/pipeline/classify-from-pages.ts` - Expand patterns and improve fallback logic
- `server/storage.ts` - Include page_type in searchPages() SELECT
- `client/src/pages/search.tsx` - Render page type badges in full-text results
- `client/src/pages/document-detail.tsx` - Show page type summary in metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)