### PR TITLE
Add per-user bookmark system

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,6 +30,7 @@ import NetworkPage from "@/pages/network";
 import SearchPage from "@/pages/search";
 import AIInsightsPage from "@/pages/ai-insights";
 import AskArchivePage from "@/pages/ask-archive";
+import BookmarksPage from "@/pages/bookmarks";
 
 function Router() {
   return (
@@ -43,6 +44,7 @@ function Router() {
       <Route path="/timeline" component={TimelinePage} />
       <Route path="/network" component={NetworkPage} />
       <Route path="/search" component={SearchPage} />
+      <Route path="/bookmarks" component={BookmarksPage} />
       <Route path="/ai-insights" component={AIInsightsPage} />
       <Route path="/ask-the-archive" component={AskArchivePage} />
       <Route component={NotFound} />

--- a/client/src/components/app-sidebar.tsx
+++ b/client/src/components/app-sidebar.tsx
@@ -33,6 +33,7 @@ import {
   BookOpen,
   Image,
   Video,
+  Bookmark,
 } from "lucide-react";
 
 interface SidebarCounts {
@@ -154,6 +155,7 @@ export function AppSidebar() {
 
   const toolItems: NavItem[] = [
     { title: "Search", url: "/search", icon: Search },
+    { title: "Bookmarks", url: "/bookmarks", icon: Bookmark },
     { title: "Ask the Archive", url: "/ask-the-archive", icon: MessageSquare },
   ];
 

--- a/client/src/pages/bookmarks.tsx
+++ b/client/src/pages/bookmarks.tsx
@@ -1,0 +1,356 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Bookmark,
+  FileText,
+  Users,
+  Search,
+  X,
+  Clock,
+  Scale,
+  AlertTriangle,
+} from "lucide-react";
+import { useBookmarks } from "@/hooks/use-bookmarks";
+import type { Person, Document } from "@shared/schema";
+
+const typeIcons: Record<string, any> = {
+  "court filing": Scale,
+  "fbi report": AlertTriangle,
+  deposition: Scale,
+};
+
+const categoryColors: Record<string, string> = {
+  "key figure": "bg-destructive/10 text-destructive",
+  associate: "bg-primary/10 text-primary",
+  victim: "bg-chart-4/10 text-chart-4",
+  witness: "bg-chart-3/10 text-chart-3",
+  legal: "bg-chart-2/10 text-chart-2",
+  political: "bg-chart-5/10 text-chart-5",
+};
+
+export default function BookmarksPage() {
+  const {
+    bookmarks,
+    personBookmarks,
+    documentBookmarks,
+    searchBookmarks,
+    deleteBookmark,
+    isLoading,
+  } = useBookmarks();
+
+  const personIds = personBookmarks.map((b) => b.entityId).filter(Boolean);
+  const documentIds = documentBookmarks.map((b) => b.entityId).filter(Boolean);
+
+  const { data: persons } = useQuery<Person[]>({
+    queryKey: ["/api/persons"],
+    staleTime: 600_000,
+    enabled: personIds.length > 0,
+  });
+
+  const personMap = new Map(persons?.map((p) => [p.id, p]) ?? []);
+
+  return (
+    <div className="flex flex-col gap-6 p-6 max-w-5xl mx-auto w-full">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2">
+          <Bookmark className="w-6 h-6 text-primary" />
+          Bookmarks
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Your saved documents, people, and searches.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading bookmarks...</p>
+      ) : bookmarks.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 gap-4">
+          <Bookmark className="w-10 h-10 text-muted-foreground/40" />
+          <p className="text-sm text-muted-foreground text-center max-w-md">
+            No bookmarks yet. Browse documents and people to start saving items.
+          </p>
+          <div className="flex gap-2">
+            <Link href="/documents">
+              <Button variant="outline" size="sm">Browse Documents</Button>
+            </Link>
+            <Link href="/people">
+              <Button variant="outline" size="sm">Browse People</Button>
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <Tabs defaultValue="all">
+          <TabsList>
+            <TabsTrigger value="all">
+              All ({bookmarks.length})
+            </TabsTrigger>
+            <TabsTrigger value="documents">
+              <FileText className="w-3.5 h-3.5 mr-1" />
+              Documents ({documentBookmarks.length})
+            </TabsTrigger>
+            <TabsTrigger value="people">
+              <Users className="w-3.5 h-3.5 mr-1" />
+              People ({personBookmarks.length})
+            </TabsTrigger>
+            <TabsTrigger value="searches">
+              <Search className="w-3.5 h-3.5 mr-1" />
+              Searches ({searchBookmarks.length})
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="all" className="flex flex-col gap-3 mt-4">
+            {documentBookmarks.length > 0 && (
+              <Section title="Documents" icon={FileText} count={documentBookmarks.length}>
+                {documentBookmarks.map((b) => (
+                  <DocumentBookmarkCard key={b.id} bookmark={b} onRemove={deleteBookmark} />
+                ))}
+              </Section>
+            )}
+            {personBookmarks.length > 0 && (
+              <Section title="People" icon={Users} count={personBookmarks.length}>
+                {personBookmarks.map((b) => {
+                  const person = personMap.get(b.entityId!);
+                  return (
+                    <PersonBookmarkCard key={b.id} bookmark={b} person={person} onRemove={deleteBookmark} />
+                  );
+                })}
+              </Section>
+            )}
+            {searchBookmarks.length > 0 && (
+              <Section title="Searches" icon={Search} count={searchBookmarks.length}>
+                <div className="flex flex-wrap gap-2">
+                  {searchBookmarks.map((b) => (
+                    <SearchBookmarkBadge key={b.id} bookmark={b} onRemove={deleteBookmark} />
+                  ))}
+                </div>
+              </Section>
+            )}
+          </TabsContent>
+
+          <TabsContent value="documents" className="flex flex-col gap-3 mt-4">
+            {documentBookmarks.length === 0 ? (
+              <EmptyTab type="documents" />
+            ) : (
+              documentBookmarks.map((b) => (
+                <DocumentBookmarkCard key={b.id} bookmark={b} onRemove={deleteBookmark} />
+              ))
+            )}
+          </TabsContent>
+
+          <TabsContent value="people" className="flex flex-col gap-3 mt-4">
+            {personBookmarks.length === 0 ? (
+              <EmptyTab type="people" />
+            ) : (
+              personBookmarks.map((b) => {
+                const person = personMap.get(b.entityId!);
+                return (
+                  <PersonBookmarkCard key={b.id} bookmark={b} person={person} onRemove={deleteBookmark} />
+                );
+              })
+            )}
+          </TabsContent>
+
+          <TabsContent value="searches" className="mt-4">
+            {searchBookmarks.length === 0 ? (
+              <EmptyTab type="searches" />
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {searchBookmarks.map((b) => (
+                  <SearchBookmarkBadge key={b.id} bookmark={b} onRemove={deleteBookmark} />
+                ))}
+              </div>
+            )}
+          </TabsContent>
+        </Tabs>
+      )}
+    </div>
+  );
+}
+
+function Section({
+  title,
+  icon: Icon,
+  count,
+  children,
+}: {
+  title: string;
+  icon: React.ComponentType<{ className?: string }>;
+  count: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <h2 className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
+        <Icon className="w-3.5 h-3.5" />
+        {title} ({count})
+      </h2>
+      <div className="flex flex-col gap-2">{children}</div>
+    </div>
+  );
+}
+
+function DocumentBookmarkCard({
+  bookmark,
+  onRemove,
+}: {
+  bookmark: { id: number; entityId: number | null; label: string | null; createdAt: string | Date | null };
+  onRemove: (id: number) => void;
+}) {
+  return (
+    <Link href={`/documents/${bookmark.entityId}`}>
+      <Card className="hover-elevate cursor-pointer">
+        <CardContent className="p-4 flex items-center gap-3">
+          <div className="flex items-center justify-center w-10 h-10 rounded-md bg-muted shrink-0">
+            <FileText className="w-5 h-5 text-muted-foreground" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <span className="text-sm font-semibold truncate block">
+              {bookmark.label || `Document #${bookmark.entityId}`}
+            </span>
+            {bookmark.createdAt && (
+              <span className="text-[10px] text-muted-foreground flex items-center gap-0.5 mt-0.5">
+                <Clock className="w-2.5 h-2.5" /> Saved {new Date(bookmark.createdAt).toLocaleDateString()}
+              </span>
+            )}
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="shrink-0 h-8 w-8 text-muted-foreground hover:text-destructive"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onRemove(bookmark.id);
+            }}
+            aria-label="Remove bookmark"
+          >
+            <X className="w-4 h-4" />
+          </Button>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+function PersonBookmarkCard({
+  bookmark,
+  person,
+  onRemove,
+}: {
+  bookmark: { id: number; entityId: number | null; label: string | null; createdAt: string | Date | null };
+  person?: Person;
+  onRemove: (id: number) => void;
+}) {
+  const name = person?.name || bookmark.label || `Person #${bookmark.entityId}`;
+  const initials = name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .slice(0, 2);
+
+  return (
+    <Link href={`/people/${bookmark.entityId}`}>
+      <Card className="hover-elevate cursor-pointer">
+        <CardContent className="p-4 flex items-center gap-3">
+          <Avatar className="w-10 h-10 border border-border shrink-0">
+            <AvatarFallback className="text-sm font-medium bg-muted">{initials}</AvatarFallback>
+          </Avatar>
+          <div className="flex-1 min-w-0">
+            <span className="text-sm font-semibold truncate block">{name}</span>
+            <div className="flex items-center gap-2 mt-0.5">
+              {person?.category && (
+                <Badge variant="secondary" className={`text-[10px] ${categoryColors[person.category] || ""}`}>
+                  {person.category}
+                </Badge>
+              )}
+              {person?.occupation && (
+                <span className="text-[10px] text-muted-foreground truncate">{person.occupation}</span>
+              )}
+            </div>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="shrink-0 h-8 w-8 text-muted-foreground hover:text-destructive"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onRemove(bookmark.id);
+            }}
+            aria-label="Remove bookmark"
+          >
+            <X className="w-4 h-4" />
+          </Button>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+function SearchBookmarkBadge({
+  bookmark,
+  onRemove,
+}: {
+  bookmark: { id: number; searchQuery: string | null; label: string | null };
+  onRemove: (id: number) => void;
+}) {
+  return (
+    <Link href={`/search?q=${encodeURIComponent(bookmark.searchQuery || bookmark.label || "")}`}>
+      <Badge variant="secondary" className="cursor-pointer group gap-1 pr-1 text-sm py-1">
+        <Search className="w-3 h-3 mr-0.5" />
+        <span>{bookmark.label || bookmark.searchQuery}</span>
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onRemove(bookmark.id);
+          }}
+          className="ml-0.5 rounded-full p-0.5 hover:bg-muted-foreground/20 opacity-0 group-hover:opacity-100 transition-opacity"
+          aria-label={`Remove saved search: ${bookmark.label || bookmark.searchQuery}`}
+        >
+          <X className="w-3 h-3" />
+        </button>
+      </Badge>
+    </Link>
+  );
+}
+
+function EmptyTab({ type }: { type: string }) {
+  const config: Record<string, { icon: any; text: string; link: string; linkText: string }> = {
+    documents: {
+      icon: FileText,
+      text: "No documents bookmarked yet.",
+      link: "/documents",
+      linkText: "Browse Documents",
+    },
+    people: {
+      icon: Users,
+      text: "No people bookmarked yet.",
+      link: "/people",
+      linkText: "Browse People",
+    },
+    searches: {
+      icon: Search,
+      text: "No searches saved yet.",
+      link: "/search",
+      linkText: "Go to Search",
+    },
+  };
+  const c = config[type] || config.documents;
+  const Icon = c.icon;
+
+  return (
+    <div className="flex flex-col items-center justify-center py-12 gap-3">
+      <Icon className="w-8 h-8 text-muted-foreground/40" />
+      <p className="text-sm text-muted-foreground">{c.text}</p>
+      <Link href={c.link}>
+        <Button variant="outline" size="sm">{c.linkText}</Button>
+      </Link>
+    </div>
+  );
+}

--- a/client/src/pages/document-detail.tsx
+++ b/client/src/pages/document-detail.tsx
@@ -26,8 +26,11 @@ import {
   Video,
   Sparkles,
   ChevronDown,
+  Bookmark,
+  BookmarkCheck,
 } from "lucide-react";
 import PdfViewer from "@/components/pdf-viewer";
+import { useBookmarks } from "@/hooks/use-bookmarks";
 import type { Document, Person, AIAnalysisDocument } from "@shared/schema";
 
 const EFTA_PATTERN = /^[A-Z]{2,6}[-_]?\d{4,}/i;
@@ -75,6 +78,7 @@ interface DocumentDetail extends Document {
 export default function DocumentDetailPage() {
   const params = useParams<{ id: string }>();
   const [, navigate] = useLocation();
+  const { isBookmarked, toggleBookmark } = useBookmarks();
   const searchParams = new URLSearchParams(window.location.search);
   const initialPage = parseInt(searchParams.get("page") || "1", 10) || 1;
 
@@ -176,11 +180,26 @@ export default function DocumentDetailPage() {
             </Button>
           </div>
         )}
-        <Link href={`/documents/compare?a=${doc.id}`}>
-          <Button variant="outline" size="sm" className="gap-1" data-testid="button-compare">
-            <ArrowLeftRight className="w-4 h-4" /> Compare
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => toggleBookmark("document", doc.id, undefined, doc.title)}
+            aria-label={isBookmarked("document", doc.id) ? `Remove bookmark: ${doc.title}` : `Bookmark ${doc.title}`}
+          >
+            {isBookmarked("document", doc.id) ? (
+              <BookmarkCheck className="w-4 h-4 text-primary" />
+            ) : (
+              <Bookmark className="w-4 h-4 text-muted-foreground" />
+            )}
           </Button>
-        </Link>
+          <Link href={`/documents/compare?a=${doc.id}`}>
+            <Button variant="outline" size="sm" className="gap-1" data-testid="button-compare">
+              <ArrowLeftRight className="w-4 h-4" /> Compare
+            </Button>
+          </Link>
+        </div>
       </div>
 
       <div className="flex flex-col gap-4">

--- a/client/src/pages/documents.tsx
+++ b/client/src/pages/documents.tsx
@@ -24,8 +24,11 @@ import {
   Video,
   LayoutGrid,
   List,
+  Bookmark,
+  BookmarkCheck,
 } from "lucide-react";
 import { useUrlFilters } from "@/hooks/use-url-filters";
+import { useBookmarks } from "@/hooks/use-bookmarks";
 import type { Document } from "@shared/schema";
 
 const ITEMS_PER_PAGE = 50;
@@ -127,6 +130,7 @@ function DocumentCardSkeleton({ index }: { index: number }) {
 }
 
 export default function DocumentsPage() {
+  const { isBookmarked, toggleBookmark } = useBookmarks();
   const [filters, setFilter, resetFilters] = useUrlFilters({
     search: "",
     type: "all",
@@ -309,37 +313,38 @@ export default function DocumentsPage() {
               {paginated?.map((doc) => {
                 const Icon = typeIcons[doc.documentType] || FileText;
                 return (
-                  <Link key={doc.id} href={`/documents/${doc.id}`}>
-                    <Card className="hover-elevate cursor-pointer" data-testid={`card-document-${doc.id}`}>
-                      <CardContent className="p-4">
-                        <div className="flex items-start gap-3">
-                          <div className="flex items-center justify-center w-10 h-10 rounded-md bg-muted shrink-0">
-                            <Icon className="w-5 h-5 text-muted-foreground" />
-                          </div>
-                          <div className="flex flex-col gap-1 min-w-0 flex-1">
-                            <div className="flex items-start justify-between gap-2">
-                              <div className="flex items-center gap-2 min-w-0">
-                                <span className="text-sm font-semibold truncate">{getDisplayTitle(doc)}</span>
-                                {isNonDescriptiveTitle(doc.title) && (
-                                  <Badge variant="outline" className="text-[9px] font-mono shrink-0">{doc.title}</Badge>
+                  <div key={doc.id} className="relative group">
+                    <Link href={`/documents/${doc.id}`}>
+                      <Card className="hover-elevate cursor-pointer" data-testid={`card-document-${doc.id}`}>
+                        <CardContent className="p-4">
+                          <div className="flex items-start gap-3">
+                            <div className="flex items-center justify-center w-10 h-10 rounded-md bg-muted shrink-0">
+                              <Icon className="w-5 h-5 text-muted-foreground" />
+                            </div>
+                            <div className="flex flex-col gap-1 min-w-0 flex-1">
+                              <div className="flex items-start justify-between gap-2">
+                                <div className="flex items-center gap-2 min-w-0">
+                                  <span className="text-sm font-semibold truncate">{getDisplayTitle(doc)}</span>
+                                  {isNonDescriptiveTitle(doc.title) && (
+                                    <Badge variant="outline" className="text-[9px] font-mono shrink-0">{doc.title}</Badge>
+                                  )}
+                                </div>
+                                {doc.sourceUrl && (
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="shrink-0"
+                                    onClick={(e) => {
+                                      e.preventDefault();
+                                      e.stopPropagation();
+                                      window.open(doc.sourceUrl!, "_blank", "noopener,noreferrer");
+                                    }}
+                                    data-testid={`button-source-${doc.id}`}
+                                  >
+                                    <ExternalLink className="w-3 h-3" />
+                                  </Button>
                                 )}
                               </div>
-                              {doc.sourceUrl && (
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  className="shrink-0"
-                                  onClick={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    window.open(doc.sourceUrl!, "_blank", "noopener,noreferrer");
-                                  }}
-                                  data-testid={`button-source-${doc.id}`}
-                                >
-                                  <ExternalLink className="w-3 h-3" />
-                                </Button>
-                              )}
-                            </div>
                             {doc.description && (
                               <p className="text-xs text-muted-foreground line-clamp-2">{doc.description}</p>
                             )}
@@ -375,27 +380,66 @@ export default function DocumentsPage() {
                       </CardContent>
                     </Card>
                   </Link>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleBookmark("document", doc.id, undefined, doc.title);
+                    }}
+                    className={`absolute top-2 right-2 p-1.5 rounded-md transition-opacity ${
+                      isBookmarked("document", doc.id)
+                        ? "opacity-100 text-primary"
+                        : "opacity-0 group-hover:opacity-100 focus:opacity-100 text-muted-foreground hover:text-primary"
+                    }`}
+                    aria-label={isBookmarked("document", doc.id) ? `Remove bookmark: ${doc.title}` : `Bookmark ${doc.title}`}
+                  >
+                    {isBookmarked("document", doc.id) ? (
+                      <BookmarkCheck className="w-4 h-4" />
+                    ) : (
+                      <Bookmark className="w-4 h-4" />
+                    )}
+                  </button>
+                </div>
                 );
               })}
             </div>
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {paginated?.map((doc) => (
-                <Link key={doc.id} href={`/documents/${doc.id}`}>
-                  <div className="group cursor-pointer" data-testid={`grid-card-${doc.id}`}>
-                    <div className="aspect-[3/4] rounded-lg overflow-hidden bg-muted border relative flex items-center justify-center transition-shadow group-hover:shadow-md group-hover:border-primary/30">
-                      <DocumentThumbnail doc={doc} />
+                <div key={doc.id} className="relative group">
+                  <Link href={`/documents/${doc.id}`}>
+                    <div className="cursor-pointer" data-testid={`grid-card-${doc.id}`}>
+                      <div className="aspect-[3/4] rounded-lg overflow-hidden bg-muted border relative flex items-center justify-center transition-shadow group-hover:shadow-md group-hover:border-primary/30">
+                        <DocumentThumbnail doc={doc} />
+                      </div>
+                      <p className="text-xs font-medium mt-1.5 line-clamp-2 leading-tight">
+                        {getDisplayTitle(doc)}
+                      </p>
+                      {doc.dateOriginal && (
+                        <span className="text-[10px] text-muted-foreground flex items-center gap-0.5 mt-0.5">
+                          <Clock className="w-2.5 h-2.5" /> {doc.dateOriginal}
+                        </span>
+                      )}
                     </div>
-                    <p className="text-xs font-medium mt-1.5 line-clamp-2 leading-tight">
-                      {getDisplayTitle(doc)}
-                    </p>
-                    {doc.dateOriginal && (
-                      <span className="text-[10px] text-muted-foreground flex items-center gap-0.5 mt-0.5">
-                        <Clock className="w-2.5 h-2.5" /> {doc.dateOriginal}
-                      </span>
+                  </Link>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleBookmark("document", doc.id, undefined, doc.title);
+                    }}
+                    className={`absolute top-1 right-1 p-1.5 rounded-md bg-background/80 backdrop-blur-sm transition-opacity ${
+                      isBookmarked("document", doc.id)
+                        ? "opacity-100 text-primary"
+                        : "opacity-0 group-hover:opacity-100 focus:opacity-100 text-muted-foreground hover:text-primary"
+                    }`}
+                    aria-label={isBookmarked("document", doc.id) ? `Remove bookmark: ${doc.title}` : `Bookmark ${doc.title}`}
+                  >
+                    {isBookmarked("document", doc.id) ? (
+                      <BookmarkCheck className="w-4 h-4" />
+                    ) : (
+                      <Bookmark className="w-4 h-4" />
                     )}
-                  </div>
-                </Link>
+                  </button>
+                </div>
               ))}
             </div>
           )}

--- a/client/src/pages/people.tsx
+++ b/client/src/pages/people.tsx
@@ -8,8 +8,9 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Users, Search, FileText, Network, ArrowUpDown, ChevronLeft, ChevronRight, X } from "lucide-react";
+import { Users, Search, FileText, Network, ArrowUpDown, ChevronLeft, ChevronRight, X, Bookmark, BookmarkCheck } from "lucide-react";
 import { useUrlFilters } from "@/hooks/use-url-filters";
+import { useBookmarks } from "@/hooks/use-bookmarks";
 import type { Person } from "@shared/schema";
 
 const ITEMS_PER_PAGE = 50;
@@ -52,6 +53,7 @@ function PersonCardSkeleton({ index }: { index: number }) {
 }
 
 export default function PeoplePage() {
+  const { isBookmarked, toggleBookmark } = useBookmarks();
   const [filters, setFilter, resetFilters] = useUrlFilters({
     search: "",
     category: "all",
@@ -172,39 +174,59 @@ export default function PeoplePage() {
                 .slice(0, 2);
 
               return (
-                <Link key={person.id} href={`/people/${person.id}`}>
-                  <Card className="hover-elevate cursor-pointer h-full" data-testid={`card-person-${person.id}`}>
-                    <CardContent className="p-4">
-                      <div className="flex items-start gap-3">
-                        <Avatar className="w-12 h-12 border border-border shrink-0">
-                          {person.imageUrl && <AvatarImage src={person.imageUrl} alt={person.name} />}
-                          <AvatarFallback className="text-sm font-medium bg-muted">
-                            {initials}
-                          </AvatarFallback>
-                        </Avatar>
-                        <div className="flex flex-col gap-1 min-w-0 flex-1">
-                          <span className="text-sm font-semibold">{person.name}</span>
-                          <span className="text-xs text-muted-foreground truncate">{person.occupation || person.role}</span>
-                          <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">{person.description}</p>
-                          <div className="flex items-center gap-2 flex-wrap mt-2">
-                            <Badge
-                              variant="secondary"
-                              className={`text-[10px] ${categoryColors[person.category] || ""}`}
-                            >
-                              {person.category}
-                            </Badge>
-                            <span className="text-[10px] text-muted-foreground flex items-center gap-0.5">
-                              <FileText className="w-2.5 h-2.5" /> {person.documentCount}
-                            </span>
-                            <span className="text-[10px] text-muted-foreground flex items-center gap-0.5">
-                              <Network className="w-2.5 h-2.5" /> {person.connectionCount}
-                            </span>
+                <div key={person.id} className="relative group">
+                  <Link href={`/people/${person.id}`}>
+                    <Card className="hover-elevate cursor-pointer h-full" data-testid={`card-person-${person.id}`}>
+                      <CardContent className="p-4">
+                        <div className="flex items-start gap-3">
+                          <Avatar className="w-12 h-12 border border-border shrink-0">
+                            {person.imageUrl && <AvatarImage src={person.imageUrl} alt={person.name} />}
+                            <AvatarFallback className="text-sm font-medium bg-muted">
+                              {initials}
+                            </AvatarFallback>
+                          </Avatar>
+                          <div className="flex flex-col gap-1 min-w-0 flex-1">
+                            <span className="text-sm font-semibold">{person.name}</span>
+                            <span className="text-xs text-muted-foreground truncate">{person.occupation || person.role}</span>
+                            <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">{person.description}</p>
+                            <div className="flex items-center gap-2 flex-wrap mt-2">
+                              <Badge
+                                variant="secondary"
+                                className={`text-[10px] ${categoryColors[person.category] || ""}`}
+                              >
+                                {person.category}
+                              </Badge>
+                              <span className="text-[10px] text-muted-foreground flex items-center gap-0.5">
+                                <FileText className="w-2.5 h-2.5" /> {person.documentCount}
+                              </span>
+                              <span className="text-[10px] text-muted-foreground flex items-center gap-0.5">
+                                <Network className="w-2.5 h-2.5" /> {person.connectionCount}
+                              </span>
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </Link>
+                      </CardContent>
+                    </Card>
+                  </Link>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleBookmark("person", person.id, undefined, person.name);
+                    }}
+                    className={`absolute top-2 right-2 p-1.5 rounded-md transition-opacity ${
+                      isBookmarked("person", person.id)
+                        ? "opacity-100 text-primary"
+                        : "opacity-0 group-hover:opacity-100 focus:opacity-100 text-muted-foreground hover:text-primary"
+                    }`}
+                    aria-label={isBookmarked("person", person.id) ? `Remove bookmark: ${person.name}` : `Bookmark ${person.name}`}
+                  >
+                    {isBookmarked("person", person.id) ? (
+                      <BookmarkCheck className="w-4 h-4" />
+                    ) : (
+                      <Bookmark className="w-4 h-4" />
+                    )}
+                  </button>
+                </div>
               );
             })}
           </div>

--- a/client/src/pages/person-detail.tsx
+++ b/client/src/pages/person-detail.tsx
@@ -21,9 +21,12 @@ import {
   Sparkles,
   BookOpen,
   ChevronRight,
+  Bookmark,
+  BookmarkCheck,
 } from "lucide-react";
 import { PersonHoverCard } from "@/components/person-hover-card";
 import { ExportButton } from "@/components/export-button";
+import { useBookmarks } from "@/hooks/use-bookmarks";
 import type { Person, Document, Connection, TimelineEvent, ProfileSection } from "@shared/schema";
 
 interface PersonAIMentions {
@@ -52,6 +55,7 @@ const categoryColors: Record<string, string> = {
 
 export default function PersonDetail() {
   const params = useParams<{ id: string }>();
+  const { isBookmarked, toggleBookmark } = useBookmarks();
 
   const { data: person, isLoading } = useQuery<PersonDetail>({
     queryKey: ["/api/persons", params.id],
@@ -123,9 +127,24 @@ export default function PersonDetail() {
                 </p>
               )}
             </div>
-            <Badge variant="secondary" className={`${categoryColors[person.category] || ""}`}>
-              {person.category}
-            </Badge>
+            <div className="flex items-center gap-1.5">
+              <Badge variant="secondary" className={`${categoryColors[person.category] || ""}`}>
+                {person.category}
+              </Badge>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => toggleBookmark("person", person.id, undefined, person.name)}
+                aria-label={isBookmarked("person", person.id) ? `Remove bookmark: ${person.name}` : `Bookmark ${person.name}`}
+              >
+                {isBookmarked("person", person.id) ? (
+                  <BookmarkCheck className="w-4 h-4 text-primary" />
+                ) : (
+                  <Bookmark className="w-4 h-4 text-muted-foreground" />
+                )}
+              </Button>
+            </div>
           </div>
 
           <div className="flex items-center gap-4 flex-wrap text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- Added bookmark buttons throughout the app: person/document detail pages, list cards, and a dedicated /bookmarks browsing page
- Bookmarks accessible via hover-reveal buttons on list/grid cards and always-visible buttons on detail pages
- New /bookmarks route with tabbed interface to browse all saved documents, people, and searches
- Added Bookmarks entry to sidebar navigation under Tools
- Bookmarks persist per browser using client ID stored in localStorage and existing API infrastructure

## Test plan
- Navigate to person/document detail pages and verify bookmark button works
- Hover over cards in people/documents list to see bookmark buttons
- Visit /bookmarks page to view all bookmarks organized by type
- Verify bookmarks persist after page navigation
- Check sidebar has Bookmarks link in Tools section

🤖 Generated with [Claude Code](https://claude.com/claude-code)