### PR TITLE
Fix CORS errors on video thumbnail presigned URLs

### DIFF
--- a/client/src/pages/documents.tsx
+++ b/client/src/pages/documents.tsx
@@ -686,7 +686,6 @@ function VideoThumbnail({ doc }: { doc: Document }) {
       video.preload = "auto";
       video.muted = true;
       video.playsInline = true;
-      video.crossOrigin = "anonymous";
       video.src = contentUrl;
 
       let released = false;


### PR DESCRIPTION
## Summary

Removes `crossOrigin = "anonymous"` from the VideoThumbnail component's dynamically created video element. The R2 bucket lacks CORS headers for the app origin, causing all video thumbnail requests to fail with CORS policy errors on the documents listing page.

Without `crossOrigin`, videos load fine for playback. The canvas capture for thumbnails will produce a tainted canvas, but the existing try/catch already handles this gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)