### PR TITLE
Revert PR #84: SDK checksum params broke video presigned URLs

### DIFF
--- a/client/src/pages/documents.tsx
+++ b/client/src/pages/documents.tsx
@@ -686,6 +686,7 @@ function VideoThumbnail({ doc }: { doc: Document }) {
       video.preload = "auto";
       video.muted = true;
       video.playsInline = true;
+      video.crossOrigin = "anonymous";
       video.src = contentUrl;
 
       let released = false;

--- a/server/r2.ts
+++ b/server/r2.ts
@@ -34,9 +34,7 @@ function getClient(): S3Client {
         secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
       },
       requestHandler: new NodeHttpHandler({ httpsAgent: { maxSockets: 100 } } as any),
-      requestChecksumCalculation: "WHEN_REQUIRED",
-      responseChecksumValidation: "WHEN_REQUIRED",
-    } as any);
+    });
   }
   return _client;
 }


### PR DESCRIPTION
## Summary

Reverts #84. Videos were working fine after PR #82. The checksum parameter changes and crossOrigin removal in PR #84 caused 503 errors on R2 presigned URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)