### PR TITLE
Improve trending and vote freshness with faster invalidation

### DIFF
--- a/client/src/hooks/use-importance-votes.ts
+++ b/client/src/hooks/use-importance-votes.ts
@@ -12,6 +12,7 @@ interface DocumentVote {
 
 const VOTES_KEY = ["/api/votes"];
 const VOTE_COUNTS_KEY = ["/api/votes/counts"];
+const MOST_VOTED_DOCS_KEY = ["/api/most-voted/documents?limit=5"];
 
 export function useImportanceVotes(documentIds: number[] = []) {
   const queryClient = useQueryClient();
@@ -103,6 +104,7 @@ export function useImportanceVotes(documentIds: number[] = []) {
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: VOTES_KEY });
       queryClient.invalidateQueries({ queryKey: VOTE_COUNTS_KEY });
+      queryClient.invalidateQueries({ queryKey: MOST_VOTED_DOCS_KEY });
     },
   });
 
@@ -118,6 +120,7 @@ export function useImportanceVotes(documentIds: number[] = []) {
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: VOTES_KEY });
       queryClient.invalidateQueries({ queryKey: VOTE_COUNTS_KEY });
+      queryClient.invalidateQueries({ queryKey: MOST_VOTED_DOCS_KEY });
     },
   });
 

--- a/client/src/hooks/use-person-votes.ts
+++ b/client/src/hooks/use-person-votes.ts
@@ -12,6 +12,7 @@ interface PersonVote {
 
 const VOTES_KEY = ["/api/person-votes"];
 const VOTE_COUNTS_KEY = ["/api/person-votes/counts"];
+const MOST_VOTED_PERSONS_KEY = ["/api/most-voted/persons?limit=6"];
 
 export function usePersonVotes(personIds: number[] = []) {
   const queryClient = useQueryClient();
@@ -99,6 +100,7 @@ export function usePersonVotes(personIds: number[] = []) {
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: VOTES_KEY });
       queryClient.invalidateQueries({ queryKey: VOTE_COUNTS_KEY });
+      queryClient.invalidateQueries({ queryKey: MOST_VOTED_PERSONS_KEY });
     },
   });
 
@@ -114,6 +116,7 @@ export function usePersonVotes(personIds: number[] = []) {
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: VOTES_KEY });
       queryClient.invalidateQueries({ queryKey: VOTE_COUNTS_KEY });
+      queryClient.invalidateQueries({ queryKey: MOST_VOTED_PERSONS_KEY });
     },
   });
 

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -156,22 +156,22 @@ export default function Dashboard() {
 
   const { data: featuredPeople, isLoading: peopleLoading } = useQuery<Person[]>({
     queryKey: ["/api/trending/persons?limit=6"],
-    staleTime: 300_000,
+    staleTime: 120_000,
   });
 
   const { data: recentDocs, isLoading: docsLoading } = useQuery<Document[]>({
     queryKey: ["/api/trending/documents?limit=5"],
-    staleTime: 300_000,
+    staleTime: 120_000,
   });
 
   const { data: mostVotedDocs, isLoading: votedDocsLoading } = useQuery<(Document & { voteCount: number })[]>({
     queryKey: ["/api/most-voted/documents?limit=5"],
-    staleTime: 300_000,
+    staleTime: 30_000,
   });
 
   const { data: mostVotedPersons } = useQuery<(Person & { voteCount: number })[]>({
     queryKey: ["/api/most-voted/persons?limit=6"],
-    staleTime: 300_000,
+    staleTime: 30_000,
   });
 
   const videoPlayer = useVideoPlayer();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -97,7 +97,7 @@ export async function registerRoutes(
     try {
       const limit = Math.min(20, Math.max(1, parseInt(req.query.limit as string) || 6));
       const persons = await storage.getTrendingPersons(limit);
-      res.set("Cache-Control", "public, max-age=300");
+      res.set("Cache-Control", "public, max-age=120");
       res.json(persons);
     } catch (error) {
       res.status(500).json({ error: "Failed to fetch trending persons" });
@@ -108,7 +108,7 @@ export async function registerRoutes(
     try {
       const limit = Math.min(20, Math.max(1, parseInt(req.query.limit as string) || 5));
       const documents = await storage.getTrendingDocuments(limit);
-      res.set("Cache-Control", "public, max-age=300");
+      res.set("Cache-Control", "public, max-age=120");
       res.json(documents.map(omitInternal));
     } catch (error) {
       res.status(500).json({ error: "Failed to fetch trending documents" });
@@ -119,7 +119,7 @@ export async function registerRoutes(
     try {
       const limit = Math.min(20, Math.max(1, parseInt(req.query.limit as string) || 5));
       const docs = await storage.getMostVotedDocuments(limit);
-      res.set("Cache-Control", "public, max-age=120");
+      res.set("Cache-Control", "public, max-age=30");
       res.json(docs.map((d) => ({ ...omitInternal(d), voteCount: d.voteCount })));
     } catch (error) {
       res.status(500).json({ error: "Failed to fetch most voted documents" });
@@ -130,7 +130,7 @@ export async function registerRoutes(
     try {
       const limit = Math.min(20, Math.max(1, parseInt(req.query.limit as string) || 5));
       const persons = await storage.getMostVotedPersons(limit);
-      res.set("Cache-Control", "public, max-age=120");
+      res.set("Cache-Control", "public, max-age=30");
       res.json(persons);
     } catch (error) {
       res.status(500).json({ error: "Failed to fetch most voted persons" });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -488,8 +488,8 @@ const networkDataCache = createCache<{
 
 const personsCache = createCache<Person[]>(5 * 60 * 1000);
 const timelineEventsCache = createCache<TimelineEvent[]>(5 * 60 * 1000);
-const trendingPersonsCache = createCache<Person[]>(5 * 60 * 1000);
-const trendingDocumentsCache = createCache<Document[]>(5 * 60 * 1000);
+const trendingPersonsCache = createCache<Person[]>(2 * 60 * 1000);
+const trendingDocumentsCache = createCache<Document[]>(2 * 60 * 1000);
 
 const countCacheMap = new Map<string, { count: number; cachedAt: number }>();
 const COUNT_TTL = 60_000;


### PR DESCRIPTION
## Summary

Faster cache refresh for trending and most-voted lists to make them feel more real-time:
- Reduced server-side cache TTLs for trending from 5 minutes to 2 minutes
- Reduced HTTP Cache-Control headers: trending from 5min → 2min, most-voted from 2min → 30s
- Reduced client staleTime to match server caches
- **Key improvement**: Immediately invalidate most-voted queries when users vote, so rankings update instantly

## Why

Trending and vote counts felt stale. The exponential decay algorithm for trending takes hours to significantly change scores, so a 2-minute cache is still very safe. For most-voted lists, immediately invalidating on vote mutations means users see their vote impact right away instead of waiting up to 5 minutes.

## Test plan

- [ ] Vote on a document/person and verify it appears in the Most Voted section instantly
- [ ] Refresh dashboard and verify trending/most-voted lists update within 2-3 minutes
- [ ] Check that repeated votes to the same item don't cause performance issues