### PR TITLE
Add dry-run and plan execution to dedup

### DIFF
--- a/scripts/pipeline/run-pipeline.ts
+++ b/scripts/pipeline/run-pipeline.ts
@@ -36,6 +36,7 @@ interface PipelineConfig {
   batchSize?: number;
   concurrency?: number;
   retryFailed?: boolean;
+  dryRun?: boolean;
 }
 
 const STAGES = [
@@ -223,7 +224,10 @@ async function runStage(stage: string, config: PipelineConfig): Promise<void> {
         break;
 
       case "dedup-persons":
-        await deduplicatePersonsInDB();
+        await deduplicatePersonsInDB({
+          dryRun: config.dryRun,
+          batchSize: config.batchSize,
+        });
         break;
 
       case "dedup-connections":
@@ -276,6 +280,8 @@ async function main() {
       config.concurrency = parseInt(args[++i], 10);
     } else if (arg === "--retry-failed") {
       config.retryFailed = true;
+    } else if (arg === "--dry-run") {
+      config.dryRun = true;
     } else if (arg === "all") {
       config.stages = [...STAGES];
     } else if (arg === "quick") {


### PR DESCRIPTION
## Summary
Added three new CLI modes to the person deduplication pipeline: `--dry-run` writes proposed actions to `data/dedup-plan.json` without modifying the database, `--execute-plan [path]` executes pending actions with resume capability and existence checks for stale plans, and `--batch N` pauses every N actions for monitoring.

## Changes
- Refactored all 7 dedup passes (0-6) to support dry-run mode by collecting `DeduplicationAction` objects instead of mutating the database
- Added `executePlan()` function with SIGINT handler for safe interruption and automatic progress saving
- New interfaces: `DeduplicationAction`, `DeduplicationPlan`, `DeduplicationOptions`
- Updated CLI entry points in both `db-loader.ts` and `run-pipeline.ts` with new flag parsing
- Backward compatible: no flags runs current behavior unchanged

## Example Workflow
\`\`\`bash
npx tsx scripts/pipeline/db-loader.ts dedup-persons --dry-run
# Review data/dedup-plan.json, set "status": "rejected" on any bad entries
npx tsx scripts/pipeline/db-loader.ts dedup-persons --execute-plan --batch 50
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)