### PR TITLE
Fix skeleton not showing on page navigation click

### DIFF
--- a/client/src/components/pdf-viewer.tsx
+++ b/client/src/components/pdf-viewer.tsx
@@ -191,6 +191,8 @@ export default function PdfViewer({ documentId, sourceUrl, publicUrl, initialPag
 
   const goToPage = (page: number) => {
     const clamped = Math.max(1, Math.min(page, totalPages));
+    if (clamped === currentPage) return;
+    setIsRendering(true);
     setCurrentPage(clamped);
     setPageInputValue(String(clamped));
     const url = new URL(window.location.href);


### PR DESCRIPTION
## Summary

Fixes skeleton loading placeholder not appearing immediately when clicking next/prev on PDF pages. The skeleton was only appearing after a render cycle delay, causing the old page to briefly remain visible.

## Changes

- Call `setIsRendering(true)` synchronously in `goToPage` instead of only in the async `renderPage` callback
- Early return if the clamped page equals current page (no-op optimization)
- Now the skeleton and page number change happen in the same React render batch, providing instant visual feedback

## Test

Click next/prev on any PDF → skeleton appears immediately, then new page renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)