### PR TITLE
Fix blank PDF pages caused by rendering to hidden canvas

### DIFF
--- a/client/src/components/pdf-viewer.tsx
+++ b/client/src/components/pdf-viewer.tsx
@@ -360,12 +360,12 @@ export default function PdfViewer({ documentId, sourceUrl, publicUrl, initialPag
 
       {/* Canvas area */}
       <div className={`overflow-auto bg-muted/20 flex justify-center p-4 ${isFullscreen ? "flex-1" : "max-h-[70vh]"}`}>
-        {isRendering && (
-          <div className="flex flex-col items-center justify-center gap-3 w-[600px] h-[780px] max-w-full">
-            <div className="w-full h-full rounded-md bg-muted/40 animate-pulse" />
-          </div>
-        )}
-        <canvas ref={canvasRef} className={`shadow-md ${isRendering ? "hidden" : ""}`} />
+        <div className="relative">
+          {isRendering && (
+            <div className="absolute inset-0 z-10 rounded-md bg-muted/40 animate-pulse" />
+          )}
+          <canvas ref={canvasRef} className="shadow-md" />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- PDF pages were rendering blank when navigating (next/prev) because pdf.js was rendering to a `display: none` canvas (Tailwind `hidden` class), which some browsers silently fail on
- Replaced the show/hide pattern with an overlay approach: the canvas is **always visible** and the skeleton loading indicator sits on top using `absolute inset-0` positioning
- When rendering completes, the overlay is removed to reveal the already-rendered canvas underneath

## Test plan

- [ ] Open a PDF document, click next/prev — pages should render correctly every time
- [ ] Skeleton loading pulse should appear immediately on click and disappear when the page is ready
- [ ] Test in both the document detail page and the document modal viewer
- [ ] Verify zoom in/out still works correctly
- [ ] Test fullscreen mode still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)