### PR TITLE
Improve Typesense search quality

### DIFF
--- a/server/migrate.ts
+++ b/server/migrate.ts
@@ -36,6 +36,12 @@ const migrations: { name: string; sql: string }[] = [
     sql: `CREATE INDEX IF NOT EXISTS idx_timeline_events_title_trgm
            ON timeline_events USING gin (title gin_trgm_ops)`,
   },
+  {
+    name: "idx_search_queries_zero_results (partial index for zero-result analytics)",
+    sql: `CREATE INDEX IF NOT EXISTS idx_search_queries_zero_results
+           ON search_queries (result_count, created_at)
+           WHERE result_count = 0`,
+  },
 ];
 
 export async function runMigrations(pool: pg.Pool): Promise<void> {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -155,6 +155,19 @@ export async function registerRoutes(
     }
   });
 
+  app.get("/api/analytics/zero-result-searches", async (req, res) => {
+    try {
+      const limit = Math.min(50, Math.max(1, parseInt(req.query.limit as string) || 20));
+      const days = Math.min(90, Math.max(1, parseInt(req.query.days as string) || 7));
+      const searches = await storage.getZeroResultSearches(limit, days);
+      res.set("Cache-Control", "public, max-age=300");
+      res.json(searches);
+    } catch (error) {
+      console.error("Failed to fetch zero-result searches:", error);
+      res.status(500).json({ error: "Failed to fetch zero-result searches" });
+    }
+  });
+
   app.get("/api/view-counts", async (req, res) => {
     try {
       const entityType = req.query.entityType as string;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -289,6 +289,7 @@ export const searchQueries = pgTable("search_queries", {
   index("idx_search_queries_query").on(table.query),
   index("idx_search_queries_created_at").on(table.createdAt),
   index("idx_search_queries_trending").on(table.query, table.createdAt),
+  index("idx_search_queries_zero_results").on(table.resultCount, table.createdAt).where(sql`result_count = 0`),
 ]);
 
 export const insertSearchQuerySchema = createInsertSchema(searchQueries).omit({ createdAt: true });


### PR DESCRIPTION
## Summary

Enhances Typesense search quality with three improvements:

- **Typo tolerance**: Increased from 1 to 2 in document page searches to handle OCR artifacts better (e.g., "Gislaine" → "Ghislaine")
- **Synonyms**: Added 4 static synonym groups (Lolita Express, Little St. James, Virginia Roberts/Giuffre, NPA) plus dynamic one-way synonyms from person aliases
- **Zero-result analytics**: Fixed search recording to capture zero-result queries and added GET /api/analytics/zero-result-searches endpoint to expose search gaps

## Changes

- `server/typesense.ts`: Added synonym definitions and helper functions; increased `num_typos` from 1 to 2 in 3 search functions
- `scripts/typesense-index.ts`: Calls synonym upsert after collection creation for both collections
- `server/storage.ts`: Removed zero-result filter; added `getZeroResultSearches()` method
- `server/routes.ts`: Added analytics endpoint
- `shared/schema.ts` + `server/migrate.ts`: Added partial index for efficient zero-result queries

## Testing

1. Re-index: Run `npx tsx scripts/typesense-index.ts --collection=persons` to apply synonyms
2. Typo tolerance: Search "Gislaine" → should find "Ghislaine" results
3. Synonyms: Search "N908JE" → should find "Lolita Express" content; search "Virginia Roberts" → should find "Virginia Giuffre" results
4. Analytics: Search a nonsense term → verify zero-result row inserted; hit GET /api/analytics/zero-result-searches → should return results

🤖 Generated with [Claude Code](https://claude.com/claude-code)